### PR TITLE
Fixes

### DIFF
--- a/data/intro missions.txt
+++ b/data/intro missions.txt
@@ -42,14 +42,14 @@ mission "Intro [0]"
 			choice
 				`	"You're a captain?"`
 					goto captain
-				`	"I'm sure, but it's time for me to get off this rock. Goodbye."
+				`	"I'm sure, but it's time for me to get off this rock. Goodbye."`
 					decline
 			label bigger
 			`	He smiles. "I'm sure you will. But there's something nice to having a ship you can pilot all by yourself. Believe me, once you have to start managing crew and paying salaries, or keeping track of a whole fleet, you'll miss these days when everything was simple."`
 			choice
 				`	"You're a captain?"`
 					goto captain
-				`	"I'm sure I'll soon find out, but it's time for me to leave the nest. Goodbye."
+				`	"I'm sure I'll soon find out, but it's time for me to leave the nest.` Goodbye."
 					decline
 			label captain
 			`	"Was," he says. "Sold off my fleet a few days ago, and I already miss it. But it was time. Time for me to retire." His voice trails off, then his face lights up. "Say, any chance I could hitch a ride with you, maybe show you the ropes, give you some pointers? I could pay you, of course."`
@@ -73,9 +73,9 @@ mission "Intro [0]"
 			choice
 				`	"Sure, glad to have you aboard."`
 					goto end
-				`	"Pay, you say? Shall I help you with your bags?"
+				`	"Pay, you say? Shall I help you with your bags?"`
 					goto end
-				`	"I always skip tutorials. Always. Even if the money is really good."
+				`	"I always skip tutorials. Always. Even if the money is really good."`
 					decline
 			label end
 			`	"Great," he says. "My name is James, by the way."`

--- a/data/map.txt
+++ b/data/map.txt
@@ -1435,22 +1435,18 @@ system Alnair
 	object
 		sprite star/m4
 		period 10
-		belt 1969
 	object Hippocrates
 		sprite planet/cloud4
 		distance 160.25
 		period 69.8377
-		belt 1969
 	object
 		sprite planet/lava7-b
 		distance 614.29
 		period 524.147
-		belt 1969
 	object
 		sprite planet/gas17-b
 		distance 1355.45
 		period 1717.98
-		belt 1969
 		object
 			sprite planet/oberon
 			distance 214
@@ -1467,7 +1463,6 @@ system Alnair
 		sprite planet/gas5-b
 		distance 2418.94
 		period 4095.72
-		belt 1969
 		object
 			sprite planet/europa
 			distance 274
@@ -5711,8 +5706,6 @@ system Ka'ch'chrai
 			sprite planet/rock7-b
 			distance 153
 			period 18.7183
-			belt 1745
-			minables titanium 4 3.84667
 	object
 		sprite planet/gas13
 		distance 3482.61
@@ -12049,14 +12042,10 @@ system whp1
 			sprite planet/callisto-b
 			distance 272
 			period 15.8216
-			belt 1805
-			minables titanium 12 5.39802
 		object
 			sprite planet/rock3-b
 			distance 406
 			period 28.8527
-			belt 1805
-			minables titanium 12 5.39802
 	object "Wormhole Beta"
 		sprite planet/wormhole-red
 		distance 2077.64

--- a/data/news.txt
+++ b/data/news.txt
@@ -93,7 +93,7 @@ news "advertisement frag"
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent" "Deep"
 	name
 		word
-			"Sponsor: Frags
+			"Sponsor: Frags "
 	portrait
 		outfit/"fragmentation grenades"
 	message
@@ -325,7 +325,7 @@ news "advertisement protector"
 			"Voted the 'ugliest ship in the sky' by Stars and Starships Magazine, the Syndicated Shipyards Protector."
 			"You don't want pretty, you want cheap and effective. We can do cheap. Syndicated Shipyards Protector."
 			"A turret platform, not a work of art. The Protector. Brought to you by Syndicated Shipyards."
-			"Protector by Syndicated Shipyards. Cheap. Durable. Effective. 
+			"Protector by Syndicated Shipyards. Cheap. Durable. Effective."
 			
 news "advertisement vanguard"
 	location
@@ -385,7 +385,7 @@ news "advertisement arrow"
 		word
 			"As fast as its name implies. The Syndicated Shipyards Arrow!"
 			"The top choice of corporate executives. The Syndicated Shipyards Arrow!"
-			"Plan your next corporate getaway with an Arrow! Brought to you by Syndicated Shipyards.
+			"Plan your next corporate getaway with an Arrow! Brought to you by Syndicated Shipyards."
 			"Not to toot our own horn, but we here at Syndicated Shipyards really outdid ourselves with the Arrow!"
 			
 news "advertisement sparrow"
@@ -758,6 +758,7 @@ news "advertisement cartel"
 	name
 		word
 			"Warning"
+	portrait
 		outfit/"laser rifle"
 	message
 		word

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -455,7 +455,7 @@ ship "Bulk Freighter" "Bulk Freighter (Proton)"
 
 
 
-ship "Carrier" "Carrier (Jump)"
+ship "Arete" "Arete (Jump)"
 	outfits
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 4
@@ -491,7 +491,7 @@ ship "Carrier" "Carrier (Jump)"
 	turret "Electron Turret"
 
 
-ship "Carrier" "Carrier (Mark II)"
+ship "Arete" "Arete (Mark II)"
 	outfits
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 4
@@ -567,7 +567,7 @@ ship "Clipper" "Clipper (Speedy)"
 
 
 
-ship "Corvette" "Corvette (Hai)"
+ship "Challenger" "Challenger (Hai)"
 	outfits
 		"Hai Tracker Pod" 4
 		"Hai Tracker" 224
@@ -583,7 +583,7 @@ ship "Corvette" "Corvette (Hai)"
 		"Hyperdrive"
 
 
-ship "Corvette" "Corvette (Missile)"
+ship "Challenger" "Challenger (Missile)"
 	outfits
 		"Torpedo Launcher" 2
 		"Torpedo" 60
@@ -606,7 +606,7 @@ ship "Corvette" "Corvette (Missile)"
 	gun "Torpedo Launcher"
 
 
-ship "Corvette" "Corvette (Speedy)"
+ship "Challenger" "Challenger (Speedy)"
 	outfits
 		"Particle Cannon" 4
 		"Heavy Anti-Missile Turret"
@@ -622,7 +622,7 @@ ship "Corvette" "Corvette (Speedy)"
 
 
 
-ship "Cruiser" "Cruiser (Heavy)"
+ship "Nomos" "Nomos (Heavy)"
 	outfits
 		"Heavy Rocket Launcher" 2
 		"Heavy Rocket" 40
@@ -657,7 +657,7 @@ ship "Cruiser" "Cruiser (Heavy)"
 	turret "Heavy Anti-Missile Turret"
 
 
-ship "Cruiser" "Cruiser (Jump)"
+ship "Nomos" "Nomos (Jump)"
 	outfits
 		"Typhoon Launcher" 2
 		"Typhoon Torpedo" 60
@@ -691,7 +691,7 @@ ship "Cruiser" "Cruiser (Jump)"
 	turret "Heavy Anti-Missile Turret"
 
 
-ship "Cruiser" "Cruiser (Mark II)"
+ship "Nomos" "Nomos (Mark II)"
 	outfits
 		"Typhoon Launcher" 2
 		"Typhoon Torpedo" 60
@@ -725,7 +725,7 @@ ship "Cruiser" "Cruiser (Mark II)"
 
 
 
-ship "Dreadnought" "Dreadnought (Jump)"
+ship "Elpis" "Elpis (Jump)"
 	outfits
 		"Torpedo Launcher" 4
 		"Torpedo" 120
@@ -993,7 +993,7 @@ ship "Freighter" "Freighter (Secret Cargo)"
 
 
 
-ship "Frigate" "Frigate (Mark II)"
+ship "Aletheia" "Aletheia (Mark II)"
 	outfits
 		"Particle Cannon" 4
 		"Anti-Missile Turret"
@@ -1109,7 +1109,7 @@ ship "Fury" "Fury (Miner)"
 
 
 
-ship "Gunboat" "Gunboat (Mark II)"
+ship "Narcissus" "Narcissus (Mark II)"
 	outfits
 		"Electron Beam" 2
 		"Electron Turret"
@@ -1764,7 +1764,7 @@ ship "Quicksilver" "Quicksilver (Scanner)"
 
 
 
-ship "Rainmaker" "Rainmaker (Mark II)"
+ship "Achlys" "Achlys (Mark II)"
 	outfits
 		"Sidewinder Missile Launcher" 4
 		"Sidewinder Missile" 180
@@ -1833,7 +1833,7 @@ ship "Roost" "Roost (Sidewinder)"
 
 
 
-ship "Scout" "Scout (Speedy)"
+ship "Caravel" "Caravel (Speedy)"
 	outfits
 		"Meteor Missile Launcher"
 		"Meteor Missile" 30

--- a/data/wanderers start.txt
+++ b/data/wanderers start.txt
@@ -972,7 +972,7 @@ mission "Wanderers: Alpha Surveillance C (Pug)"
 
 
 
-ship "Carrier" "Carrier (Alpha)"
+ship "Arete" "Arete (Alpha)"
 	outfits
 		"Ion Cannon" 2
 		"Hai Tracker Pod" 4

--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -437,7 +437,7 @@ outfit "Proton Gun"
 		"firing force" 2
 		"firing heat" 60
 	description "The Syndicated Systems Proton Gun may seem like a knockoff Particle Cannon to the untrained eye, but this rapid fire cannon is anything but."
-	description "	If you are from the school of Spray and Pray, this is the gun for you.
+	description "	If you are from the school of Spray and Pray, this is the gun for you."
 	
 outfit "Proton Fragment"
 	weapon

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -89,19 +89,19 @@ namespace {
 }
 	// Ship categories, be sure to preserve legacy ship classes (From base endless sky) to support crossover plugins.
 const vector<string> Ship::CATEGORIES = {
-	"Yacht"
-	"Freighter"
-	"Container Ship"
-	"Gunship"
-	"Corvette"
-	"Frigate"
-	"Destroyer"
-	"Cruiser"
-	"Battlecruiser"
-	"Battleship"
-	"Carrier"
-	"Colony Ship"
-	"City Ship"
+	"Yacht",
+	"Freighter",
+	"Container Ship",
+	"Gunship",
+	"Corvette",
+	"Frigate",
+	"Destroyer",
+	"Cruiser",
+	"Battlecruiser",
+	"Battleship",
+	"Carrier",
+	"Colony Ship",
+	"City Ship",
 	"Transport",
 	"Light Freighter",
 	"Heavy Freighter",


### PR DESCRIPTION
Fixes up a bunch of errors. 

Ase these seem to be more related to missing assets, this does not fix:
Skipping unrecognized attribute:
  news "advertisement syndicate propaganda"
    name
      portrait/"syndicate"

Skipping unrecognized attribute:
  news "advertisement northern union"
    name
      portrait/"advertisement"

In addition, this does not fix the unrecognized empty outfits nor the various errors that pop up once a save file is made.

Here are the error files from [before](https://github.com/kikotheexile/Endless-Sky-Civil-War/files/3856024/before.txt) and [after](https://github.com/kikotheexile/Endless-Sky-Civil-War/files/3856029/now.txt) these changes.

