### PR TITLE
Add crew data type to enhance salary calculation

### DIFF
--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -116,6 +116,8 @@
 		<Unit filename="source/Conversation.h" />
 		<Unit filename="source/ConversationPanel.cpp" />
 		<Unit filename="source/ConversationPanel.h" />
+		<Unit filename="source/Crew.cpp" />
+		<Unit filename="source/Crew.h" />
 		<Unit filename="source/DataFile.cpp" />
 		<Unit filename="source/DataFile.h" />
 		<Unit filename="source/DataNode.cpp" />

--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		A9CC526D1950C9F6004E4E22 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9CC526C1950C9F6004E4E22 /* Cocoa.framework */; };
 		A9D40D1A195DFAA60086EE52 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9D40D19195DFAA60086EE52 /* OpenGL.framework */; };
 		B5DDA6942001B7F600DBA76A /* News.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5DDA6922001B7F600DBA76A /* News.cpp */; };
+		C9779AE623922EB5009310A2 /* Crew.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9779AE423922EB5009310A2 /* Crew.cpp */; };
 		DF8D57E11FC25842001525DA /* Dictionary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57DF1FC25842001525DA /* Dictionary.cpp */; };
 		DF8D57E51FC25889001525DA /* Visual.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57E21FC25889001525DA /* Visual.cpp */; };
 		DFAAE2A61FD4A25C0072C0A8 /* BatchDrawList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAAE2A21FD4A25C0072C0A8 /* BatchDrawList.cpp */; };
@@ -432,6 +433,8 @@
 		A9D40D19195DFAA60086EE52 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
 		B5DDA6922001B7F600DBA76A /* News.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = News.cpp; path = source/News.cpp; sourceTree = "<group>"; };
 		B5DDA6932001B7F600DBA76A /* News.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = News.h; path = source/News.h; sourceTree = "<group>"; };
+		C9779AE423922EB5009310A2 /* Crew.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Crew.cpp; path = source/Crew.cpp; sourceTree = "<group>"; };
+		C9779AE523922EB5009310A2 /* Crew.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Crew.h; path = source/Crew.h; sourceTree = "<group>"; };
 		DF8D57DF1FC25842001525DA /* Dictionary.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Dictionary.cpp; path = source/Dictionary.cpp; sourceTree = "<group>"; };
 		DF8D57E01FC25842001525DA /* Dictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Dictionary.h; path = source/Dictionary.h; sourceTree = "<group>"; };
 		DF8D57E21FC25889001525DA /* Visual.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Visual.cpp; path = source/Visual.cpp; sourceTree = "<group>"; };
@@ -504,6 +507,8 @@
 				A96862ED1AE6FD0A004FE1FE /* Conversation.h */,
 				A96862EE1AE6FD0A004FE1FE /* ConversationPanel.cpp */,
 				A96862EF1AE6FD0A004FE1FE /* ConversationPanel.h */,
+				C9779AE423922EB5009310A2 /* Crew.cpp */,
+				C9779AE523922EB5009310A2 /* Crew.h */,
 				A96862F01AE6FD0A004FE1FE /* DataFile.cpp */,
 				A96862F11AE6FD0A004FE1FE /* DataFile.h */,
 				A96862F21AE6FD0A004FE1FE /* DataNode.cpp */,
@@ -922,6 +927,7 @@
 				A96863F41AE6FD0E004FE1FE /* ShipInfoDisplay.cpp in Sources */,
 				A96863C21AE6FD0E004FE1FE /* FrameTimer.cpp in Sources */,
 				A96863D81AE6FD0E004FE1FE /* MissionAction.cpp in Sources */,
+				C9779AE623922EB5009310A2 /* Crew.cpp in Sources */,
 				A96863FA1AE6FD0E004FE1FE /* SpriteQueue.cpp in Sources */,
 				A96863E21AE6FD0E004FE1FE /* Phrase.cpp in Sources */,
 				628BDAEF1CC5DC950062BCD2 /* PlanetLabel.cpp in Sources */,

--- a/data/crew.txt
+++ b/data/crew.txt
@@ -1,0 +1,29 @@
+# Copyright (c) 2019 by Luke Arndt
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+crew "regular"
+  name "Regular Crew"
+  salary 100
+
+# crew "pilot"
+#   name "Pilots"
+#   salary 250
+#   "avoids flagship"
+#   "place at" 1
+# 
+# crew "junior officer"
+#   name "Junior Officers"
+#   salary 500
+#   "ship population per member" 5
+# 
+# crew "senior officer"
+#   name "Senior Officers"
+#   salary 2000
+#   "ship population per member" 20

--- a/data/help.txt
+++ b/data/help.txt
@@ -28,7 +28,7 @@ help "disabled"
 	`If the ship that disabled you is still hanging around, you might need to hail them first and bribe them to leave you alone.`
 
 help "hiring"
-	`Hiring extra crew is only helpful if you plan on capturing enemy ships. Each crew member other than yourself is paid 100 credits per day. Larger ships require more than one crew member, but you will automatically hire the minimum number of crew when you buy those ships.`
+	`Hiring extra crew is only helpful if you plan on capturing enemy ships. Each crew member other than yourself is paid a salary every day. Larger ships require more than one crew member, but you will automatically hire the minimum number of crew when you buy those ships.`
 	`Crew members take up space that can otherwise be used for passengers.`
 
 help "jobs"

--- a/source/Crew.cpp
+++ b/source/Crew.cpp
@@ -1,0 +1,248 @@
+/* Crew.cpp
+Copyright (c) 2019 by Luke Arndt
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "Crew.h"
+#include "Files.h"
+#include "GameData.h"
+
+using namespace std;
+
+void Crew::Load(const DataNode &node)
+{
+	if(node.Size() >= 2)
+	{
+		id = node.Token(1);
+		name = id;
+	}
+	
+	for(const DataNode &child : node)
+	{
+		if(child.Size() >= 2)
+		{
+			if(child.Token(0) == "name")
+				name = child.Token(1);
+			else if(child.Token(0) == "parked salary")
+				parkedSalary = max((int)child.Value(1), 0);
+			else if(child.Token(0) == "place at")
+				for(int crewNumber = 1; crewNumber < child.Size(); ++crewNumber)
+					placeAt.push_back(max((int)child.Value(crewNumber), 0));
+			else if(child.Token(0) == "ship population per member")
+				shipPopulationPerMember = max((int)child.Value(1), 0);
+			else if(child.Token(0) == "salary")
+				salary = max((int)child.Value(1), 0);
+			else
+				child.PrintTrace("Skipping unrecognized attribute:");
+		}
+		else if(child.Token(0) == "avoids escorts")
+			avoidsEscorts = true;
+		else if(child.Token(0) == "avoids flagship")
+			avoidsFlagship = true;
+		else
+			child.PrintTrace("Skipping incomplete attribute:");
+	}
+}
+
+
+
+int64_t Crew::CalculateSalaries(const vector<shared_ptr<Ship>> &ships, const Ship * flagship, const bool includeExtras)
+{
+	int64_t totalSalaries = 0;
+
+	for(const shared_ptr<Ship> &ship : ships)
+	{
+		totalSalaries += Crew::SalariesForShip(
+			ship,
+			ship.get() == flagship,
+			includeExtras
+		);
+	}
+	
+	return totalSalaries;
+}
+
+
+
+int64_t Crew::CostOfExtraCrew(const vector<shared_ptr<Ship>> &ships, const Ship * flagship)
+{
+	// Calculate with and without extras and return the difference.
+	return Crew::CalculateSalaries(ships, flagship, true)
+		- Crew::CalculateSalaries(ships, flagship, false);
+}
+
+
+
+int64_t Crew::NumberOnShip(const Crew &crew, const shared_ptr<Ship> &ship, const bool isFlagship, const bool includeExtras)
+{
+	// If this is the flagship, check if this crew avoids the flagship.
+	if(isFlagship && crew.AvoidsFlagship())
+		return 0;
+	// If this is an escort, check if this crew avoids escorts.
+	if(!isFlagship && crew.AvoidsEscorts())
+		return 0;
+	
+	const int64_t countableCrewMembers = includeExtras
+		? ship->Crew()
+		: ship->RequiredCrew();
+	
+	int64_t numberOnShip = 0;
+	// Total up the placed crew members within the ship's countable crew
+	for(int64_t crewNumber : crew.PlaceAt())
+		if(crewNumber <= countableCrewMembers)
+			++numberOnShip;
+		
+	// Prevent division by zero so that the universe doesn't implode.
+	if(crew.ShipPopulationPerMember())
+	{
+		// Figure out how many of this kind of crew we have, by population.
+		numberOnShip = max(
+			numberOnShip,
+			countableCrewMembers / crew.ShipPopulationPerMember()
+		);
+	}
+	
+	return numberOnShip;
+}
+
+
+
+int64_t Crew::SalariesForShip(const shared_ptr<Ship> &ship, const bool isFlagship, const bool includeExtras)
+{
+	// We don't need to pay dead people.
+	if(ship->IsDestroyed())
+		return 0;
+	
+	// Build a manifest of all of the crew members on the ship
+	const map<const string, int64_t> manifest = ShipManifest(ship, isFlagship, includeExtras);
+	
+	// Sum up all of the crew's salaries
+	// For performance, check if the ship is parked once, not every loop
+	int64_t salariesForShip = 0;
+	if(ship->IsParked())
+		for(pair<const string, int64_t> entry : manifest)
+			salariesForShip += GameData::Crews().Get(entry.first)->ParkedSalary() * entry.second;
+	else
+		for(pair<const string, int64_t> entry : manifest)
+			salariesForShip += GameData::Crews().Get(entry.first)->Salary() * entry.second;
+		
+	return salariesForShip;
+}
+
+
+
+const map<const string, int64_t> Crew::ShipManifest(const shared_ptr<Ship> &ship, bool isFlagship, bool includeExtras)
+{
+	int64_t crewAccountedFor = 0;
+	// A crew ID, the number on the ship, and their individual salary amount
+	tuple<string, int64_t, int64_t> cheapestCrew;
+	// Map of a crew ID to the crew type paired with the number on the ship
+	map<const string, int64_t> manifest;
+	
+	// Check that we have crew data before proceeding
+	if(GameData::Crews().size() < 1)
+	{
+		Files::LogError("Error: could not find any crew member definitions in the data files.");
+		return manifest;
+	}
+	
+	// Add up the salaries for all of the special crew members
+	for(const pair<const string, Crew> &crewPair : GameData::Crews())
+	{
+		const Crew crew = crewPair.second;
+		// Figure out how many of this type of crew are on this ship
+		int numberOnShip = Crew::NumberOnShip(
+			crew,
+			ship,
+			isFlagship,
+			includeExtras
+		);
+		
+		// Add the crew members to the manifest
+		manifest[crew.Id()] = numberOnShip;
+		
+		// Add the crew members to the total so far
+		crewAccountedFor += numberOnShip;
+		
+		// If this is the cheapest crew type so far, keep track of it
+		// Use non-parked salaries so that crew are consistent
+		if(get<0>(cheapestCrew).empty() || crew.Salary() < get<2>(cheapestCrew))
+			cheapestCrew = make_tuple(crew.Id(), numberOnShip, crew.Salary());
+	}
+	
+	// Figure out how many crew members we still need to account for
+	int64_t remainingCrewMembers = (includeExtras
+			? ship->Crew()
+			: ship->RequiredCrew()
+		) - crewAccountedFor
+		// If this is the flagship, one of the crew members is the player
+		- isFlagship;
+	
+	// Fill out the ranks with the cheapest type of crew member
+	manifest[get<0>(cheapestCrew)] = get<1>(cheapestCrew) + remainingCrewMembers;
+	
+	return manifest;
+}
+
+
+
+bool Crew::AvoidsEscorts() const
+{
+	return avoidsEscorts;
+}
+
+
+
+bool Crew::AvoidsFlagship() const
+{
+	return avoidsFlagship;
+}
+
+
+
+int64_t Crew::ParkedSalary() const
+{
+	return parkedSalary;
+}
+
+
+
+int64_t Crew::Salary() const
+{
+	return salary;
+}
+
+
+
+int64_t Crew::ShipPopulationPerMember() const
+{
+	return shipPopulationPerMember;
+}
+
+
+
+const string &Crew::Id() const
+{
+	return id;
+}
+
+
+
+const string &Crew::Name() const
+{
+	return name;
+}
+
+
+
+const vector<int64_t> &Crew::PlaceAt() const
+{
+	return placeAt;
+}

--- a/source/Crew.h
+++ b/source/Crew.h
@@ -1,0 +1,71 @@
+/* Crew.h
+Copyright (c) 2019 by Luke Arndt
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef CREW_H_
+#define CREW_H_
+
+#include "Ship.h"
+
+class Crew
+{
+public:
+	// Calculate one day's salaries for the Player's fleet
+	static int64_t CalculateSalaries(const std::vector<std::shared_ptr<Ship>> &ships, const Ship * flagship, const bool includeExtras = true);
+	
+	// Calculate the total cost of the flagship's extra crew
+	static int64_t CostOfExtraCrew(const std::vector<std::shared_ptr<Ship>> &ships, const Ship * flagship);
+
+	// Figure out how many of a given crew member are on a ship
+	static int64_t NumberOnShip(const Crew &crew, const std::shared_ptr<Ship> &ship, const bool isFlagship, const bool includeExtras = true);
+
+	// Calculate one day's salaries for a ship
+	static int64_t SalariesForShip(const std::shared_ptr<Ship> &ship, const bool isFlagship, const bool includeExtras = true);
+
+	// List the crew members on a ship, and how many there are of each type
+	static const std::map<const std::string, int64_t> ShipManifest(const std::shared_ptr<Ship> &ship, bool isFlagship, bool includeExtras = true);
+
+	// Load a definition for a crew member.
+	void Load(const DataNode &node);
+	
+	bool AvoidsEscorts() const;
+	bool AvoidsFlagship() const;
+	int64_t ParkedSalary() const;
+	int64_t Salary() const;
+	int64_t ShipPopulationPerMember() const;
+	const std::string &Id() const;
+	const std::string &Name() const;
+	const std::vector<int64_t> &PlaceAt() const;
+
+private:
+	// If true, the crew member will not appear on escorts
+	bool avoidsEscorts = false;
+	// If true, the crew member will not appear on the flagship
+	bool avoidsFlagship = false;
+	// The number of credits paid daily while parked (minimum 0)
+	int64_t parkedSalary = 0;
+	// The number of credits paid daily (minimum 0)
+	int64_t salary = 100;
+	// Every nth crew member on the ship will be this crew member
+	int64_t shipPopulationPerMember = 0;
+	// The id that the crew member is stored against in GameData::Crews()
+	std::string id;
+	// The display name for this kind of crew members (plural, Title Case)
+	std::string name;
+	// The crew member will be placed at these crew member numbers if possible
+	// Note: if multiple crew definitions claim the same crew positions,
+	// we can end up paying for more crew than we expect to.
+	// To avoid this, don't place different crew members in the same spots.
+	// Example usage: "place at" 1 3 5 7 13
+	std::vector<int64_t> placeAt;
+};
+
+#endif

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Color.h"
 #include "Command.h"
 #include "Conversation.h"
+#include "Crew.h"
 #include "DataFile.h"
 #include "DataNode.h"
 #include "DataWriter.h"
@@ -67,6 +68,7 @@ using namespace std;
 namespace {
 	Set<Color> colors;
 	Set<Conversation> conversations;
+	Set<Crew> crews;
 	Set<Effect> effects;
 	Set<GameEvent> events;
 	Set<Fleet> fleets;
@@ -592,6 +594,13 @@ const Set<Conversation> &GameData::Conversations()
 
 
 
+const Set<Crew> &GameData::Crews()
+{
+	return crews;
+}
+
+
+
 const Set<Effect> &GameData::Effects()
 {
 	return effects;
@@ -923,6 +932,8 @@ void GameData::LoadFile(const string &path, bool debugMode)
 				node.Value(2), node.Value(3), node.Value(4), node.Value(5));
 		else if(key == "conversation" && node.Size() >= 2)
 			conversations.Get(node.Token(1))->Load(node);
+		else if(key == "crew" && node.Size() >= 2)
+			crews.Get(node.Token(1))->Load(node);
 		else if(key == "effect" && node.Size() >= 2)
 			effects.Get(node.Token(1))->Load(node);
 		else if(key == "event" && node.Size() >= 2)

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -24,6 +24,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 class Color;
 class Conversation;
+class Crew;
 class DataNode;
 class DataWriter;
 class Date;
@@ -93,6 +94,7 @@ public:
 	
 	static const Set<Color> &Colors();
 	static const Set<Conversation> &Conversations();
+	static const Set<Crew> &Crews();
 	static const Set<Effect> &Effects();
 	static const Set<GameEvent> &Events();
 	static const Set<Fleet> &Fleets();

--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -12,6 +12,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "HiringPanel.h"
 
+#include "Crew.h"
 #include "FillShader.h"
 #include "GameData.h"
 #include "Information.h"
@@ -79,9 +80,9 @@ void HiringPanel::Draw()
 	info.SetString("fleet unused", to_string(fleetUnused));
 	info.SetString("passengers", to_string(passengers));
 	
-	static const int DAILY_SALARY = 100;
-	int salary = DAILY_SALARY * (fleetRequired - 1);
-	int extraSalary = DAILY_SALARY * flagshipExtra;
+	const Ship * playerFlagship = player.Flagship();
+	int64_t salary = Crew::CalculateSalaries(player.Ships(), playerFlagship, false);
+	int64_t extraSalary = Crew::CostOfExtraCrew(player.Ships(), playerFlagship);
 	info.SetString("salary required", to_string(salary));
 	info.SetString("salary extra", to_string(extraSalary));
 	

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Audio.h"
 #include "ConversationPanel.h"
+#include "Crew.h"
 #include "DataFile.h"
 #include "DataWriter.h"
 #include "Dialog.h"
@@ -668,21 +669,7 @@ Account &PlayerInfo::Accounts()
 // Calculate how much the player pays in daily salaries.
 int64_t PlayerInfo::Salaries() const
 {
-	// Don't count extra crew on anything but the flagship.
-	int64_t crew = 0;
-	const Ship *flagship = Flagship();
-	if(flagship)
-		crew = flagship->Crew() - flagship->RequiredCrew();
-	
-	// A ship that is "parked" remains on a planet and requires no salaries.
-	for(const shared_ptr<Ship> &ship : ships)
-		if(!ship->IsParked() && !ship->IsDestroyed())
-			crew += ship->RequiredCrew();
-	if(!crew)
-		return 0;
-	
-	// Every crew member except the player receives 100 credits per day.
-	return 100 * (crew - 1);
+	return Crew::CalculateSalaries(ships, Flagship());
 }
 
 


### PR DESCRIPTION
This is a port of endless-sky/endless-sky/pull/4670
at endless-sky/endless-sky@056a463

## Feature Details

We can now calculate crew salaries using more factors than just how many
crew members the player has in their active ships. This will allow us to
create various different kinds of crew, each paid different amounts.

This goal of this system is to allow for interesting trade-offs in fleet
design. It also lets us create anti-snowballing mechanics, which
help prevent the player from suddenly catapulting upward in power.

Previously, salaries were constrained linearly: 100 credits per crew
member across the entire fleet. Since income potential grows at a
non-linear rate, linearly-scaling salaries soon become irrelevant.

Using this tool, we can make salaries increase in proportion to actual
power gain. This should hopefully add interesting decisions for the
player - do they really need all those heavy warships, or will they cost
too much to maintain?

### Context:

Fleet management is currently very simple from an economic perspective.
Crew members cost a flat 100 credits per day, regardless of what they
actually do on their ship. Salary costs can be mostly ignored because
the ships' benefits to the player far outweigh them.

### Changes:

This commit makes crew salaries more complex by introducing the ability
for us to define various kinds of crew members in the data files. The
system currently supports the following attributes, with default values:

- name
- "avoids escorts" (false)
- "avoids flagship" (false)
- "parked salary" (0)
- "place at" (empty list)
- salary (100)
- "ship population per member" (0)

The commit includes a `crew.txt` data file with a few commented-out
examples, plus an active data node for the default crew members.

Since we also display the salaries on the Hiring panel, this commit
changes that code to call the appropriate functions on the `Crew` class.

Merging this PR will not meaningfully affect gameplay. It just gives us
some tools that we can use for later changes.

### Considerations:

I considered adding this logic to the `PlayerInfo` class, since that is
where crew salaries used to be calculated. However, `PlayerInfo` is a
really huge class with a ton of responsibilities. When editing it, I
often got lost if I moved my editor window too far. Instead, I added a
new class called `Crew`.

Ideally it would be nice to update the fleet panel so that players can
see how many of each crew member on a given ship and how much salary
they are paid each day. This would help with decision making. We don't
need to do that yet, though.
