### PR TITLE
Add profit sharing to the crew system, with UI

### DIFF
--- a/data/crew.txt
+++ b/data/crew.txt
@@ -8,22 +8,32 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
+crew "player"
+  name "Player"
+  shares 1000
+  "avoids escorts"
+  "place at" 1
+
 crew "regular"
   name "Regular Crew"
   salary 100
+  shares 1
 
-# crew "pilot"
-#   name "Pilots"
-#   salary 250
-#   "avoids flagship"
-#   "place at" 1
-# 
-# crew "junior officer"
-#   name "Junior Officers"
-#   salary 500
-#   "ship population per member" 5
-# 
-# crew "senior officer"
-#   name "Senior Officers"
-#   salary 2000
-#   "ship population per member" 20
+crew "pilot"
+  name "Pilot"
+  salary 250
+  shares 20
+  "avoids flagship"
+  "place at" 1
+
+crew "junior officer"
+  name "Junior Officers"
+  salary 500
+  shares 10
+  "ship population per member" 5
+
+crew "senior officer"
+  name "Senior Officers"
+  salary 2000
+  shares 50
+  "ship population per member" 20

--- a/source/Crew.h
+++ b/source/Crew.h
@@ -24,12 +24,21 @@ public:
 	// Calculate the total cost of the flagship's extra crew
 	static int64_t CostOfExtraCrew(const std::vector<std::shared_ptr<Ship>> &ships, const Ship * flagship);
 
+	// Generate a fleet summary for display
+	static std::vector<std::pair<int64_t, std::string>> FleetSummary(const PlayerInfo &player);
+	
 	// Figure out how many of a given crew member are on a ship
 	static int64_t NumberOnShip(const Crew &crew, const std::shared_ptr<Ship> &ship, const bool isFlagship, const bool includeExtras = true);
+
+	// Return the total number of profit shares for a ship
+	static int64_t SharesForShip(const std::shared_ptr<Ship> &ship, const bool isFlagship, const bool includeExtras = true);
 
 	// Calculate one day's salaries for a ship
 	static int64_t SalariesForShip(const std::shared_ptr<Ship> &ship, const bool isFlagship, const bool includeExtras = true);
 
+	// Share profits the fleet. Returns how many credits were distributed.
+	static int64_t ShareProfit(const std::vector<std::shared_ptr<Ship>> &ships, const Ship * flagship, const int64_t grossProfit);
+	
 	// List the crew members on a ship, and how many there are of each type
 	static const std::map<const std::string, int64_t> ShipManifest(const std::shared_ptr<Ship> &ship, bool isFlagship, bool includeExtras = true);
 
@@ -39,7 +48,9 @@ public:
 	bool AvoidsEscorts() const;
 	bool AvoidsFlagship() const;
 	int64_t ParkedSalary() const;
+	int64_t ParkedShares() const;
 	int64_t Salary() const;
+	int64_t Shares() const;
 	int64_t ShipPopulationPerMember() const;
 	const std::string &Id() const;
 	const std::string &Name() const;
@@ -52,8 +63,12 @@ private:
 	bool avoidsFlagship = false;
 	// The number of credits paid daily while parked (minimum 0)
 	int64_t parkedSalary = 0;
+	// The crew member's profit shares while parked (minimum 0)
+	int64_t parkedShares = 0;
 	// The number of credits paid daily (minimum 0)
-	int64_t salary = 100;
+	int64_t salary = 0;
+	// The crew member's shares in the fleet's profits (minimum 0)
+	int64_t shares = 0;
 	// Every nth crew member on the ship will be this crew member
 	int64_t shipPopulationPerMember = 0;
 	// The id that the crew member is stored against in GameData::Crews()

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1302,7 +1302,9 @@ bool PlayerInfo::TakeOff(UI *ui)
 			income += cost;
 		}
 	}
-	accounts.AddCredits(income);
+	int64_t grossProfit = income - totalBasis;
+	int64_t sharedProfit = Crew::ShareProfit(ships, Flagship(), grossProfit);
+	accounts.AddCredits(income - sharedProfit);
 	cargo.Clear();
 	stockDepreciation = Depreciation();
 	if(sold)
@@ -1310,10 +1312,12 @@ bool PlayerInfo::TakeOff(UI *ui)
 		// Report how much excess cargo was sold, and what profit you earned.
 		ostringstream out;
 		out << "You sold " << sold << " tons of excess cargo for " << Format::Credits(income) << " credits";
-		if(totalBasis && totalBasis != income)
-			out << " (for a profit of " << (income - totalBasis) << " credits).";
-		else
-			out << ".";
+		if(grossProfit > 0)
+			out << " (for a profit of " << Format::Credits(grossProfit) << " credits)";
+		if(sharedProfit > 0)
+			out << " and distributed " + Format::Credits(sharedProfit) + " credits among your crew";
+		out << ".";
+		
 		Messages::Add(out.str());
 	}
 	

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -13,6 +13,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "PlayerInfoPanel.h"
 
 #include "Command.h"
+#include "Crew.h"
 #include "Font.h"
 #include "FontSet.h"
 #include "Format.h"
@@ -524,6 +525,11 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		table.Draw("fleet: " + deterrenceRating, dim);
 		table.Draw("(-" + Format::Decimal(deterrenceLevel, 1) + ")", dim);
 	}
+	
+	// Fleet summary:
+	vector<pair<int64_t, string>> fleetSummary = Crew::FleetSummary(player);
+	DrawList(fleetSummary, table, "fleet summary: ");
+	
 	// Other special information:
 	auto salary = Match(player, "salary: ", "");
 	sort(salary.begin(), salary.end());

--- a/source/ShipInfoPanel.h
+++ b/source/ShipInfoPanel.h
@@ -60,6 +60,7 @@ private:
 	void DrawOutfits(const Rectangle &bounds, Rectangle &cargoBounds);
 	void DrawWeapons(const Rectangle &bounds);
 	void DrawCargo(const Rectangle &bounds);
+	void DrawCrew(const Rectangle &bounds);
 	
 	// Helper functions.
 	void DrawLine(const Point &from, const Point &to, const Color &color) const;

--- a/source/TradingPanel.h
+++ b/source/TradingPanel.h
@@ -52,8 +52,9 @@ private:
 	// everything except outfits.
 	bool sellOutfits = false;
 	
-	// Keep track of how much we sold and how much profit was made.
+	// Keep track of how much we sold, and how much profit we made / shared.
 	int tonsSold = 0;
+	int64_t sharedProfit = 0;
 	int64_t profit = 0;
 };
 


### PR DESCRIPTION
### Context

This is the second commit in a series that introduces crew-based
mechanics to that game. The first (#10) added a crew data type that
drives a more advanced salary calculator. Increasing the scaling factor
of crew salaries was an important step, but alone it isn't enough.

One of the game's fundamental economic issues is that freight, plunder,
and capture increase the player's net worth far more than story rewards.
This makes missions unappealing after the early game, and makes the
story's credit rewards unsatisfying.

### Changes

This commit introduces a profit sharing system that forces the player to
share some of their profits with their crew. Here's how it works:

- In the crew definitions, we can now add a `shares` attribute to each
  entry. Each crew member of that type has that many shares in the
  fleet's profits.

- When the player sells cargo or outfits using the Trading Panel, the
  game calculates how much profit they made. Outfits are considered
  to be pure profit because they are most likely plunder. (This is just a
  recap of how the game works already.)

- Instead of immediately awarding the credits to the player, the game
  now figures out how many shares the player and their crew have in
  the fleet's profits. The player receives their share of the profit instead
  of the entire sum.

- On takeoff, the game displays a message showing how much profit the
  player made while trading on the planet (existing behaviour). As of this
  commit, the message now also shows how much profit the player
  distributed among the crew.
  
- The Ship Info Panel now shows a breakdown of shares and salaries for
  each ship, divided into crew member types and with a total at the
  bottom of the display.
  
- The Player Info Panel now shows a Fleet Summary, which shows the total
  crew salaries and shares. It also shows profit share as a percentage.

- To make testing easier, the crew definitions are no longer commented
  out by default.

### Considerations

In a future change, I want to add a system that keeps track of morale on
a per-ship basis. Profit sharing will be one of the most effective ways
to improve the crew's morale. 

If the player uses the outfitter to sell plunder, they don't have to
share the resulting profits with the fleet. This is because the game
does not keep track of how much the player paid for a particular outfit.

I considered creating a cost-basis system for outfits as a solution to
the trading panel vs outfitter issue. After thinking about it at length,
I realised that it will be okay for the player to have a way to sell
plunder without sharing profit because the morale system will cover it.
We just need to make sure that profit shares are important enough to
crew morale that a player who uses the outfitter as a workaround will
end up with an unhappy and disloyal fleet.
