### PR TITLE
Changes to Cloaking

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2425,7 +2425,7 @@ bool AI::DoCloak(Ship &ship, Command &command)
 		// or 40% farther away before it begins decloaking again.
 		double hysteresis = ship.Commands().Has(Command::CLOAK) ? .4 : 0.;
 		// If cloaking costs nothing, and no one has asked you for help, cloak at will.
-		bool cloakFreely = (fuelCost <= 0.) && !ship.GetShipToAssist();
+		bool cloakFreely = (fuelCost <= 0.) && !ship.GetShipToAssist() && ship.Shields() < 0.2 && ship.Heat() < 0.8;
 		// If this ship is injured / repairing, it should cloak while under threat.
 		bool cloakToRepair = (ship.Health() < RETREAT_HEALTH + hysteresis)
 				&& (attributes.Get("shield generation") || attributes.Get("hull repair rate"));


### PR DESCRIPTION
Changes `cloakFreely` so that it will only trigger if the ship has <20% shields and <80% heat.  Ships will continue to cloak as normal when damaged and to avoid enemies as before.

Untested as of right now, but will test and report back based on Vanilla ES compile version.