### PR TITLE
Add active heating and heat consumption

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1695,7 +1695,7 @@ void Ship::DoGeneration()
 		energy += attributes.Get("energy generation") - attributes.Get("energy consumption");
 		energy -= ionization;
 		fuel += attributes.Get("fuel generation");
-		heat += attributes.Get("heat generation");
+		heat += attributes.Get("heat generation") - attributes.Get("heat consumption");
 		heat -= coolingEfficiency * attributes.Get("cooling");
 		
 		// Convert fuel into energy and heat only when the required amount of fuel is available.
@@ -1705,7 +1705,21 @@ void Ship::DoGeneration()
 			energy += attributes.Get("fuel energy");
 			heat += attributes.Get("fuel heat");
 		}
-		
+
+		// Apply active heating before cooling.
+		double activeHeating = attributes.Get("heat generation") * attributes.Get("active heating");
+		double heatConsumption = attributes.Get("heat consumption");
+		if(activeHeating > 0.)
+		{
+			if(heatConsumption > 0.)
+			{
+				double trueActiveHeating = min(heatConsumption, attributes.Get("heat generation")) * attributes.Get("active heating");
+				heat += trueActiveHeating;
+			}
+			else
+				heat += activeHeating;
+		}
+
 		// Apply active cooling. The fraction of full cooling to apply equals
 		// your ship's current fraction of its maximum temperature.
 		double activeCooling = coolingEfficiency * attributes.Get("active cooling");


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #n/a

## Feature Details
Adds two new attributes relating to heat: heat consumption and active heating.
Heat consumption removes the specified amount of heat every frame.
Active heating multiplies the heat generation by the specified fraction. If heat consumption is also present and higher than heat generation, it is multiplied by the specified active heating and added to the ship's heat.

## Usage Examples
```
outfit "heat generator"
    "fuel consumption" 0.05 
    "active heating" 1.23
    "fuel energy" -2.5
    
outfit "heat converter"
    "energy generation" 22.5
    "heat consumption" 55
```