### PR TITLE
Update credits to show change in game

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -1,13 +1,11 @@
-Welcome to Endless Sky!
-version 0.9.10
+Welcome to Endless Sky: Stories!
 
 This game is open source.
 To report bugs, give feedback,
 or contribute to story writing,
 artwork, or programming, visit:
-https://endless-sky.github.io
-The game's Steam forums
-Discord (invite: ZeuASSx)
+https://github.com/kikotheexile
+Discord (invite: ND788CC)
 
 Programming
   Michael Zahniser


### PR DESCRIPTION
Not the thing I was planning to do, but figured I should do nonetheless.

What this changes:
Changes Endless Sky to Endless Sky: Stories
Removes the version number, as the game currently is in a versionless state
Changes the link from the base game's web page to @kikotheexile's github profile. Doesn't have the full link to the repo as it doesn't fit in the box
Removes the mention of the Steam Forums, as ESS doesn't yet have them
Changes Discord invite from ESC to the ESS Discord