### PR TITLE
Complementary patch for PR #27

### DIFF
--- a/data/weapons.txt
+++ b/data/weapons.txt
@@ -878,7 +878,7 @@ outfit "Railgun Slug"
 	category "Ammunition"
 	cost 60
 	thumbnail "outfit/railslug"
-	"mass" 0.02
+	"mass" 0.01
 	"railgun slug capacity" -1
 	description "These railgun slugs incorporate energy-discharging capacitors that deal a small amount of hull damage even when the target's shields are functioning, and they can punch crippling holes in the hull of a ship whose shields are down."
 
@@ -951,9 +951,9 @@ outfit "Meteor Missile"
 	category "Ammunition"
 	cost 500
 	thumbnail "outfit/meteor"
-	"mass" .2
+	"mass" .1
 	"meteor capacity" -1
-	description "A Meteor Missile serves as ammunition for the Meteor Missile Launcher. Each missile launcher has the capacity for 60 missiles; you cannot install missiles if you have not first purchased a launcher to store them in."
+	description "A Meteor Missile serves as ammunition for the Meteor Missile Launcher. You cannot install Meteor Missiles if you have not first purchased a launcher to store them in."
 
 outfit "Meteor Missile Box"
 	plural "Meteor Missile Boxes"
@@ -962,7 +962,7 @@ outfit "Meteor Missile Box"
 	thumbnail "outfit/meteor storage"
 	"mass" 2
 	"outfit space" -5
-	"meteor capacity" 15
+	"meteor capacity" 30
 	ammo "Meteor Missile"
 	description "The Meteor Missile Box is used to store extra ammunition for Meteor Missile Launchers."
 
@@ -1000,7 +1000,7 @@ outfit "Meteor Missile Launcher"
 		"hull damage" 160
 		"hit force" 220
 		"missile strength" 6
-	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. Meteors are quickly destroyed by anti-missile systems, and their infrared tracking systems have trouble homing in on targets with low heat levels. Nevertheless, their large warheads can spell doom for poorly-defended targets when the missiles are fired in great numbers."
+	description "The Meteor Missile is the cheapest and simplest homing weapon available in human space. Meteor Missiles are quickly destroyed by anti-missile systems, and their infrared tracking systems have trouble homing in on targets with low heat levels. Nevertheless, their large warheads can spell doom for poorly-defended targets when the missiles are fired in great numbers."
 
 effect "meteor fire"
 	sprite "effect/meteor fire"
@@ -1014,17 +1014,17 @@ outfit "Sidewinder Missile"
 	category "Ammunition"
 	cost 900
 	thumbnail "outfit/sidewinder"
-	"mass" .2
+	"mass" .1
 	"sidewinder capacity" -1
-	description "The Sidewinder Missile is ammunition for the Sidewinder Missile Launcher. You cannot install a missile without a launcher to fire it from."
+	description "The Sidewinder Missile is ammunition for the Sidewinder Missile Launcher. You cannot install a Sidewinder Missile without a launcher to fire it from."
 
 outfit "Sidewinder Missile Rack"
 	category "Ammunition"
 	cost 20000
 	thumbnail "outfit/sidewinder storage"
-	"mass" 2.4
-	"outfit space" -7
-	"sidewinder capacity" 23
+	"mass" 2
+	"outfit space" -14
+	"sidewinder capacity" 120
 	ammo "Sidewinder Missile"
 	description "The Sidewinder Missile Rack is used to store extra ammunition for Sidewinder Missile Launchers."
 
@@ -1036,7 +1036,7 @@ outfit "Ranger Missile Launcher"
 	"outfit space" -29
 	"weapon capacity" -29
 	"gun ports" -1
-	"sidewinder capacity" 200
+	"sidewinder capacity" 240
 	weapon
 		sprite "projectile/sidewinder"
 			"no repeat"
@@ -1077,9 +1077,9 @@ outfit "Javelin"
 	category "Ammunition"
 	cost 50
 	thumbnail "outfit/javelin"
-	"mass" .04
+	"mass" .02
 	"javelin capacity" -1
-	description "A Javelin missile is ammunition for the Javelin Pod; without a Pod to store them in you cannot purchase or use Javelins. Each pod stores up to 400 Javelins."
+	description "A Javelin missile is ammunition for the Javelin Pod. You cannot install a Javelin without a launcher to fire it from."
 
 outfit "Javelin Storage Crate"
 	category "Ammunition"
@@ -1087,7 +1087,7 @@ outfit "Javelin Storage Crate"
 	thumbnail "outfit/javelin storage"
 	"mass" 2
 	"outfit space" -6
-	"javelin capacity" 100
+	"javelin capacity" 200
 	ammo "Javelin"
 	description "The Javelin Storage Crate is used to store extra ammunition for Javelin Pods."
 
@@ -1127,15 +1127,15 @@ outfit "Torpedo"
 	thumbnail "outfit/torpedo"
 	"mass" .4
 	"torpedo capacity" -1
-	description "Torpedoes are ammunition for the Torpedo Launcher. Each Torpedo Launcher can hold 10 of them. You cannot install torpedoes unless you have also installed a launcher to fire them from."
+	description "Torpedoes are ammunition for the Torpedo Launcher. You cannot install a Torpedo without a launcher to fire it from."
 
 outfit "Torpedo Storage Rack"
 	category "Ammunition"
 	cost 21000
 	thumbnail "outfit/torpedo storage"
-	"mass" 3
-	"outfit space" -9
-	"torpedo capacity" 15
+	"mass" 6
+	"outfit space" -8
+	"torpedo capacity" 5
 	ammo "Torpedo"
 	description "The Torpedo Storage Rack is used to store extra ammunition for Torpedo Launchers."
 
@@ -1143,7 +1143,7 @@ outfit "Torpedo Launcher"
 	category "Secondary Weapons"
 	cost 80000
 	thumbnail "outfit/torpedo launcher"
-	"mass" 13
+	"mass" 11
 	"outfit space" -15
 	"weapon capacity" -15
 	"gun ports" -1
@@ -1174,7 +1174,7 @@ outfit "Torpedo Launcher"
 		"piercing" .9
 		"hit force" 300
 		"missile strength" 10
-	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge. Torpedo launchers are also much larger than other missile systems, so they are most often found in capital ships."
+	description "Torpedoes are the most powerful homing weapon, but they move slowly enough that fast ships can simply outrun them, making them most useful against large targets or against small ships at times when they are too distracted to dodge. Torpedo Launchers are also much larger than other missile systems, so they are most often found in capital ships."
 
 effect "torpedo fire"
 	sprite "effect/torpedo fire"
@@ -1190,15 +1190,15 @@ outfit "Typhoon Torpedo"
 	thumbnail "outfit/typhoon"
 	"mass" .5
 	"typhoon capacity" -1
-	description "Typhoon Torpedoes are ammunition for the Typhoon Launcher. Each launcher can hold 15 of them. You cannot install Typhoon Torpedoes unless you have also installed a launcher to fire them from."
+	description "Typhoon Torpedoes are ammunition for the Typhoon Launcher. You cannot install a Typhoon Torpedo without a launcher to fire it from."
 
 outfit "Typhoon Storage Tube"
 	category "Ammunition"
 	cost 40500
 	thumbnail "outfit/typhoon storage"
-	"mass" 2.5
-	"outfit space" -10
-	"typhoon capacity" 15
+	"mass" 7
+	"outfit space" -15
+	"typhoon capacity" 8
 	ammo "Typhoon Torpedo"
 	description "The Typhoon Storage Tube is used to store extra ammunition for Typhoon Launchers."
 
@@ -1206,7 +1206,7 @@ outfit "Typhoon Launcher"
 	category "Secondary Weapons"
 	cost 260000
 	thumbnail "outfit/typhoon launcher"
-	"mass" 20
+	"mass" 12.5
 	"outfit space" -20
 	"weapon capacity" -20
 	"gun ports" -1
@@ -1250,9 +1250,9 @@ outfit "Heavy Rocket"
 	category "Ammunition"
 	cost 2000
 	thumbnail "outfit/rocket"
-	"mass" .5
+	"mass" .25
 	"rocket capacity" -1
-	description "Heavy Rockets are ammunition for the Heavy Rocket Launcher. You cannot install one unless you have first installed a launcher to fire it from. Each launcher holds up to 40 rockets."
+	description "Heavy Rockets are ammunition for the Heavy Rocket Launcher. You cannot install a Heavy Rocket without a launcher to fire it from."
 
 outfit "Heavy Rocket Rack"
 	category "Ammunition"
@@ -1260,7 +1260,7 @@ outfit "Heavy Rocket Rack"
 	thumbnail "outfit/rocket storage"
 	"mass" 2
 	"outfit space" -7
-	"rocket capacity" 10
+	"rocket capacity" 20
 	ammo "Heavy Rocket"
 	description "The Heavy Rocket Rack is used to store extra ammunition for Heavy Rocket Launchers."
 
@@ -1295,7 +1295,7 @@ outfit "Heavy Rocket Launcher"
 		"hull damage" 720
 		"hit force" 600
 		"missile strength" 16
-	description "Heavy Rockets are the most powerful missile weapon available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
+	description "Heavy Rockets are the most powerful missile weapon available, but at a price: Instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
 
 effect "heavy rocket hit"
 	sprite "effect/explosion/huge"
@@ -1389,7 +1389,7 @@ outfit "Gatling Gun Ammo"
 	category "Ammunition"
 	cost 4
 	thumbnail "outfit/bullet"
-	"mass" .002
+	"mass" .001
 	"gatling round capacity" -1
 	description "This simple cartridge is the ammunition for the Gatling Gun, with a projectile of depleted nuclear fuel or an illuminated tracer round. Since this ammunition is primarily manufactured on pirate worlds by slave children in poor working conditions, muzzle velocity can vary by up to 30%, and tracer distribution is seldom uniform."
 
@@ -1400,7 +1400,7 @@ outfit "Bullet Boxes"
 	thumbnail "outfit/bullet storage"
 	"mass" 2
 	"outfit space" -5
-	"gatling round capacity" 1500
+	"gatling round capacity" 3000
 	ammo "Gatling Gun Ammo"
 	description "Bullet Boxes are used to store extra ammunition for Gatling Guns."
 


### PR DESCRIPTION
## SUMMARY
- Made missile descriptions consistent.
- Increased ammo box storage to match 50% of the launcher's storage. Decreased torpedo ammo box storage capacity for the same reason.
- Halved ammo mass so the mass of full launchers/ammo boxes matches their outfit space again.
- Slightly reduced some launcher/ammo box mass for the same reason as the line above.

Related:
#27 