### PR TITLE
Bugfixes in intro and pirate "hard" start

### DIFF
--- a/data/intro conversations.txt
+++ b/data/intro conversations.txt
@@ -9,7 +9,7 @@
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 conversation "intro"
-	`	Would you like a quick breifing on the controls, interface, and how the game is played before we begin?`
+	`	Would you like a quick briefing on the controls, interface, and how the game is played before we begin?`
 	choice
 		`	Yes.`
 			goto menu
@@ -19,12 +19,12 @@ conversation "intro"
 			goto skip
 
 	label skip
-		apply
+	`	The introduction has been skipped, the tutorial rejected, and the "hard" start selected. Please name your character.`
+	name
+	apply
 		set "a pirates life"
-		`	The introduction has been skipped, the tutorial rejected, and the "hard" start selected. Please name your character.`
-		name
-		`	Have fun out there, <first> <last>!`
-			accept
+	`	Have fun out there, <first> <last>!`
+		accept
 	label menu
 	`	What would you like to know?`
 	choice

--- a/data/intro missions.txt
+++ b/data/intro missions.txt
@@ -31,8 +31,11 @@ mission "A pirate's life!"
 		has "a pirates life"
 		
 	on offer
-		dialog `The <npc> has landed next to you! This bounty hunter has been on your tail for weeks now, almost as if they're tracking your movements somehow. The Vanguard is slow and easy enough to avoid, but having a hostile Cruiser chasing you will make paying off this loan considerably more difficult.`
-
+		conversation
+			`The <npc> has landed next to you! This bounty hunter has been on your tail for weeks now, almost as if they're tracking your movements somehow. The Vanguard is slow and easy enough to avoid, but having a hostile Cruiser chasing you will make paying off this loan considerably more difficult.`
+				accept
+	
+	on accept
 	npc kill
 		personality nemesis
 		government "Bounty Hunter"


### PR DESCRIPTION
When playtesting the new introduction and the hard mode, a couple bugs stood out to me: The skip introduction option when making a new pilot is completely broken, and you can refuse to be chased by a Vanguard bounty hunter in the reformed pirate start (hard mode). This PR fixes the skip option, throwing players straight into the shipyard, and changes the dialog box so there is no decline option when the game tells the player about the Vanguard.