### PR TITLE
Add GameWindow to cbp

### DIFF
--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -180,6 +180,8 @@
 		<Unit filename="source/GameData.h" />
 		<Unit filename="source/GameEvent.cpp" />
 		<Unit filename="source/GameEvent.h" />
+		<Unit filename="source/GameWindow.cpp" />
+		<Unit filename="source/GameWindow.h" />
 		<Unit filename="source/Government.cpp" />
 		<Unit filename="source/Government.h" />
 		<Unit filename="source/HailPanel.cpp" />


### PR DESCRIPTION
In the recent pull, the GameWindow code was missing from the cbp. This adds it into it.