### PR TITLE
Error Fixes

### DIFF
--- a/data/intro conversations.txt
+++ b/data/intro conversations.txt
@@ -54,7 +54,7 @@ conversation "intro"
 	choice
 		`	When I'm landed on a planet.`
 			goto planetui
-		`	Navigating "Shipyards" and "Outfitters."
+		`	Navigating "Shipyards" and "Outfitters."`
 			goto outfitters
 		`	What to watch while in space.`
 			goto space
@@ -87,9 +87,10 @@ conversation "intro"
 	`(L) to land on your target planet, station, or moon in this system.`
 	`(T) to hail target ships, (Shift+T) to hail selected planets.`
 	``
-		`	You can find more info on your controls by visiting the preferences screen. Access that by pressing the (ESC) key and clicking Preferences.`
+	`	You can find more info on your controls by visiting the preferences screen. Access that by pressing the (ESC) key and clicking Preferences.`
+	choice
 		`	(Back to Basics.)`
-			got basics
+			goto basics
 		`	(Back to Menu.)`
 			goto menu
 		`	(Continue to the intro.)`

--- a/data/intro missions.txt
+++ b/data/intro missions.txt
@@ -22,7 +22,7 @@ mission "Trust fund baby"
 		conversation 
 			`	You recieve notice that some of your inheritance has been transferred to your account. This is <payment> that can go to paying down your loan or customizing your ship!`
 		payment 250000
-		accept
+			accept
 
 mission "A pirate's life!"
 	invisible

--- a/data/job board generic.txt
+++ b/data/job board generic.txt
@@ -126,7 +126,7 @@ mission "Escort (Tiny, Northern, Dangerous Origin)"
 			variant
 				"Star Barge"
 	on complete
-	"reputation: Merchant" += 1
+		"reputation: Merchant" += 1
 		payment 15000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
@@ -175,7 +175,7 @@ mission "Escort (Small, Northern, Dangerous Destination)"
 			variant
 				"Freighter"
 	on complete
-	"reputation: Merchant" += 3
+		"reputation: Merchant" += 3
 		payment 60000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
@@ -280,7 +280,7 @@ mission "Escort (Medium, Northern, Dangerous Destination)"
 			variant
 				"Freighter"
 	on complete
-	"reputation: Merchant" += 3
+		"reputation: Merchant" += 3
 		payment 90000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
@@ -2712,7 +2712,7 @@ mission "Bounty Hunting (Medium)"
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
-	"reputation: Independent" += 3
+		"reputation: Independent" += 3
 		payment 200000
 		dialog phrase "generic bounty hunting payment dialog"
 

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -1577,7 +1577,6 @@ planet Nimbus
 		fleet "Small Syndicate" 4
 
 planet "No-Where Station"
-	attributes 
 	landscape land/sivael6
 	description `This inegmatic station is known only for how handidly and rapidly they turn people away. They allow you to dock for repairs, but you aren't permitted to leave the common room of the Spaceport.`
 	spaceport `You can only imagine what the interior of the station looks like, considering you have never seen it and aren't likely to. The common room, however, is rather plain and filled with dull and uninspiring fixtures. Although visitors are a rare few, you can still sometimes share a coffee with a stranger.`

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -10677,7 +10677,6 @@ system Tarazed
 			distance 177.193
 			period 18.9732
 			offset 31.5543
-			belt 1169
 	object
 		sprite planet/gas15-b
 		distance 1880.55

--- a/data/news.txt
+++ b/data/news.txt
@@ -724,6 +724,7 @@ news "advertisement syndicate propaganda"
 	name
 		word
 			"Obvious Propaganda"
+	portrait
 		portrait/"syndicate"
 	message
 		word
@@ -773,6 +774,7 @@ news "advertisement northern union"
 	name
 		word
 			"Advertisement"
+	portrait
 		portrait/"advertisement"
 	message
 		word

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -3729,7 +3729,8 @@ ship "Dart"
 ship "Bolt"
 	sprite "ship/marrowe"
 	thumbnail "thumbnail/marrowe"
-	"cost" 1320000
+	attributes
+		"cost" 1320000
 		"shields" 2300
 		"hull" 500
 		"required crew" 2
@@ -3770,7 +3771,8 @@ ship "Bolt"
 ship "Missile"
 	sprite "ship/marroww"
 	thumbnail "thumbnail/marroww"
-	"cost" 1320000
+	attributes
+		"cost" 1320000
 		"shields" 2300
 		"hull" 500
 		"required crew" 2

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -3292,7 +3292,7 @@ ship "Unnamed Prototype"
 	"never disabled"
 	thumbnail "thumbnail/kestrel"
 	attributes
-		License:
+		licenses
 			Not-For-Sale
 		category "Cruiser"
 		"cost" 14700000

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -3006,7 +3006,8 @@ ship "Archon"
 	
 ship "Archon" "Archon (Cloaked)"
 	"never disabled"
-	"cost" 1000000000
+	attributes
+		"cost" 1000000000
 		"shields" 4000000
 		"hull" 1000000
 		"required crew" 1

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -4022,7 +4022,8 @@ ship "Merlin"
 ship "Peregrine" "Marauder Falcon (Engines)"
 	sprite "ship/mfalcone"
 	thumbnail "thumbnail/mfalcone"
-"cost" 13900000
+	attributes
+		"cost" 13900000
 		"shields" 14100
 		"hull" 4100
 		"required crew" 43
@@ -4075,7 +4076,8 @@ ship "Peregrine" "Marauder Falcon (Engines)"
 ship "Harpy" "Marauder Falcon (Weapons)"
 	sprite "ship/mfalconw"
 	thumbnail "thumbnail/mfalconw"
-"cost" 13900000
+	attributes
+		"cost" 13900000
 		"shields" 14100
 		"hull" 4100
 		"required crew" 43
@@ -4185,7 +4187,8 @@ ship "Phoenix"
 ship "Huma" "Marauder Firebird (Engines)"
 	sprite "ship/mfirebirde"
 	thumbnail "thumbnail/mfirebirds"
-"cost" 4100000
+	attributes
+		"cost" 4100000
 		"shields" 7000
 		"hull" 3000
 		"required crew" 10
@@ -4231,7 +4234,8 @@ ship "Huma" "Marauder Firebird (Engines)"
 ship "Fenghuang" "Marauder Firebird (Weapons)"
 	sprite "ship/mfirebirdw"
 	thumbnail "thumbnail/mfirebirdw"
-"cost" 4100000
+	attributes
+		"cost" 4100000
 		"shields" 7000
 		"hull" 3000
 		"required crew" 10
@@ -4339,7 +4343,8 @@ ship "Lindworm"
 ship "Selma" "Marauder Leviathan (Engines)"
 	sprite "ship/mleviathane"
 	thumbnail "thumbnail/mleviathane"
-"cost" 10800000
+	attributes
+		"cost" 10800000
 		"shields" 16000
 		"hull" 5500
 		"required crew" 48
@@ -4385,7 +4390,8 @@ ship "Selma" "Marauder Leviathan (Engines)"
 ship "Bakunawa" "Marauder Leviathan (Weapons)"
 	sprite "ship/mleviathanw"
 	thumbnail "thumbnail/mleviathanw"
-"cost" 10800000
+	attributes
+		"cost" 10800000
 		"shields" 16000
 		"hull" 5500
 		"required crew" 48
@@ -4494,7 +4500,8 @@ ship "Zonetail"
 ship "Lesser Devil" "Marauder Manta (Engines)"
 	sprite "ship/mmantae"
 	thumbnail "thumbnail/mmantae"
-"cost" 3740000
+	attributes
+		"cost" 3740000
 		"shields" 6500
 		"hull" 1750
 		"required crew" 7
@@ -4545,7 +4552,8 @@ ship "Lesser Devil" "Marauder Manta (Engines)"
 ship "Spinetail" "Marauder Manta (Weapons)"
 	sprite "ship/mmantaw"
 	thumbnail "thumbnail/mmantaw"
-"cost" 3740000
+	attributes
+		"cost" 3740000
 		"shields" 6500
 		"hull" 1750
 		"required crew" 7
@@ -4649,7 +4657,8 @@ ship "Gallium"
 ship "Mercury" "Marauder Quicksilver (Engines)"
 	sprite "ship/mquicksilvere"
 	thumbnail "thumbnail/mquicksilvere"
-"cost" 1200000
+	attributes
+		"cost" 1200000
 		"shields" 3500
 		"hull" 900
 		"required crew" 4
@@ -4692,7 +4701,8 @@ ship "Mercury" "Marauder Quicksilver (Engines)"
 ship "Phosphorus" "Marauder Quicksilver (Weapons)"
 	sprite "ship/mquicksilverw"
 	thumbnail "thumbnail/mquicksilverw"
-"cost" 1200000
+	attributes
+		"cost" 1200000
 		"shields" 3500
 		"hull" 900
 		"required crew" 4
@@ -4789,7 +4799,8 @@ ship "Crow"
 ship "Rook" "Marauder Raven (Engines)"
 	sprite "ship/mravene"
 	thumbnail "thumbnail/mravene"
-"cost" 2750000
+	attributes
+		"cost" 2750000
 		"shields" 5200
 		"hull" 1600
 		"required crew" 7
@@ -4831,7 +4842,8 @@ ship "Rook" "Marauder Raven (Engines)"
 ship "Sturnus" "Marauder Raven (Weapons)"
 	sprite "ship/mravenw"
 	thumbnail "thumbnail/mravenw"
-"cost" 2750000
+	attributes
+		"cost" 2750000
 		"shields" 5200
 		"hull" 1600
 		"required crew" 7
@@ -4931,7 +4943,8 @@ ship "Sliver"
 ship "Needle" "Marauder Splinter (Engines)"
 	sprite "ship/msplintere"
 	thumbnail "thumbnail/msplintere"
-"cost" 3400000
+	attributes
+		"cost" 3400000
 		"shields" 5700
 		"hull" 1950
 		"required crew" 8
@@ -4979,7 +4992,8 @@ ship "Needle" "Marauder Splinter (Engines)"
 ship "Sting" "Marauder Splinter (Weapons)"
 	sprite "ship/msplinterw"
 	thumbnail "thumbnail/msplinterw"
-"cost" 3400000
+	attributes
+		"cost" 3400000
 		"shields" 5700
 		"hull" 1950
 		"required crew" 8

--- a/data/story free worlds.txt
+++ b/data/story free worlds.txt
@@ -178,88 +178,88 @@ mission "Pact Questioning"
 		log "Apparently the Navy is suspicious of anyone working with the Southern Mutual Defense Pact. Come to think of it though, it's unclear what that officer's rank or position was."
 			conversation
 			`	Until now, you've generally been left alone by the officers of the republic Navy that are a fixture of most spaceports, so you're rather surprised when you're accosted by an officer in a plain black uniform, missing the usual markings of rank that you're familiar with, save a pin in the shape of an eye, the blue iris staring you down from where the usual rank badge goes. "Excuse me, Captain <Last>, could I speak with you for a few minutes?"`
-		choice
-			`	"I've got time. What's the job?"`
+			choice
+				`	"I've got time. What's the job?"`
 				goto job
-			`	"Sorry, I've got to see a man about some bull semen."`
+				`	"Sorry, I've got to see a man about some bull semen."`
 				goto what
 			label job
 			`	"No work today, unfortunetly." The officer replies. "I just have some questions for you."`
-		choice
-			`	"I only have time for paying customers."`
-				goto customer
-			`	"I've got a couple minutes, ask away."`
-				goto ask
-		label customer
+			choice
+				`	"I only have time for paying customers."`
+					goto customer
+				`	"I've got a couple minutes, ask away."`
+					goto ask
+			label customer
 			`	"I really must insist, this shouldn't take long." The officer replies. You get the feeling that complying is in your best interest.`
-		choice
-			`	"Alright, make it quick then."`
-			goto ask
-			`	"Well, since you're asking so nicely."`
-			goto ask
-		label what
+			choice
+				`	"Alright, make it quick then."`
+				goto ask
+				`	"Well, since you're asking so nicely."`
+				goto ask
+			label what
 			`	 It's obvious that was not the response the officer was expecting, and he takes a moment to maintain his composure. "You are keeping it on ice, yes? I'm sure you have a couple minutes to spare. I just have some questions and you can be on your way."`
-		choice
-			`	"I only have time for paying customers."`
-				goto customer
-			`	"I've got a couple minutes, ask away."`
-				goto ask
-		label customer
+			choice
+				`	"I only have time for paying customers."`
+					goto customer
+				`	"I've got a couple minutes, ask away."`
+					goto ask
+			label customer
 			`	"I really must insist, this shouldn't take long." The officer replies. You get the feeling that complying is in your best interest.`
-		choice
-			`	"Alright, make it quick then."`
-			goto ask
-			`	"Well, since you're asking so nicely."`
-			goto ask
-		label ask
+			choice
+				`	"Alright, make it quick then."`
+				goto ask
+				`	"Well, since you're asking so nicely."`
+				goto ask
+			label ask
 			`	"Thank you," he says. "Am I correct that you performed some missions for the Southern Defense Pact, this would be before they declared themselves the Free Worlds`."`
 			`	"I've done some work here and there."`
-			goto easy
-		label business
+				goto easy
+			label business
 			`	The officer's expression does not change. "I'm going to level with you, I already know what I need to know, but I have some paperwork that needs filled out. So you can either make this easy on both of us, or I can ground your ship while I subpoena your records."`
 			`	"I've done a little work for them here and there." You admit.`
 				goto easy
-		label easy
+			label easy
 			`	"Tell me," he says, "was there someone who you reported to every time, or was it someone different every time?" As he is speaking, you again search him over for any indentifiers on his uniform. The Navy personell you have encountered in the past have a name badge on their lapel and rank insignia on their collar, but his uniform is entirely blank, save the eye on his lapel that has been staring you down the entire conversation.`
 			choice
-			`	"I don't really pay attention to names, just my bank account."`
-			goto account
-			`	"Her last name was a season I think, I don't really remember."`
-			goto freya
-		label account	
+				`	"I don't really pay attention to names, just my bank account."`
+					goto account
+				`	"Her last name was a season I think, I don't really remember."`
+					goto freya
+			label account	
 			`	"Always the same with you merchants, isn't it?" He complains. "Would five grand effectively jog your memory?"`
 			choice
-			`	"I wish, but I honestly don't remember."`
-			goto wish
-			`	"My memory, no. But my bank account seems to remember one Freya Winters."`
-			goto freya
-		label wish
+				`	"I wish, but I honestly don't remember."`
+					goto wish
+				`	"My memory, no. But my bank account seems to remember one Freya Winters."`
+					goto freya
+			label wish
 			`	"No matter then. Can you tell me what nature of work you were performing?"`
 			choice
-			`	"Nothing worthy of this sort of interoggation, just some pirate recon."`
-			label recon
-			`	"Oh all the usual ways of undermining the republic, but mostly pirate recon."`
-			label recon
-		label freya
+				`	"Nothing worthy of this sort of interoggation, just some pirate recon."`
+					goto recon
+				`	"Oh all the usual ways of undermining the republic, but mostly pirate recon."`
+					goto recon
+			label freya
 			`	"Ah yes, Miss Winters," he says. "A very capable woman, though she's more skilled as an engineer than as a leader. Can you tell me what sort of work you were performing for her?"`
 			choice
-			`	"Nothing worthy of this sort of interoggation, just some pirate recon."`
+				`	"Nothing worthy of this sort of interoggation, just some pirate recon."`
+					goto recon
+				`	"Oh all the usual ways of undermining the republic, but mostly pirate recon."`
+					goto recon
 			label recon
-			`	"Oh all the usual ways of undermining the republic, but mostly pirate recon."`
-			label recon
-		label recon
 			`	If your response was meant to be funny, he doesn't laugh. "Are you certain your reconnaissance was only targeted at pirates?" he asks. "Did they collect only your logs on pirate ships, or on every ship you saw?"`
 			choice
-			`	"No idea, I handed over all my sensor logs for the area, what they did with them is their problem."`
+				`	"No idea, I handed over all my sensor logs for the area, what they did with them is their problem."`
+					goto problem
+				`	"Just the pirate ships, not much else in the areas I was sent to. Do you want the same information so maybe the Navy can do their job?"`
+					goto job
 			label problem
-			`	"Just the pirate ships, not much else in the areas I was sent to. Do you want the same information so maybe the Navy can do their job?"`
-			label job
-		label problem
 			`	"So it would appear." He replies. "No further questions then, thank you for your time." And with that, he walks away, leaving you wondering what sort of trouble you have gotten yourself into.`
-			decline
-		label job
+				decline
+			label job
 			`	"That wont be necessary." He replies coldly. "You're free to go for now, but I'll be in touch if I have any further questions." This last part sounds a bit like a threat, but you decide not to comment and instead take your leave, occasionally glancing back over your shoulder as you do to confirm you aren't being watched or followed. Of either, you're unsure.`
-			decline
+				decline
 
 mission "FW Recon 0"
 	name "Transport Militia Officer"
@@ -956,7 +956,7 @@ mission "FW Katya 3"
 			`	"Well," she says, "it started when the Syndicate began experimenting with fully automated mining facilities on uninhabitable planets. Pirates started raiding the mines to steal equipment, and the Syndicate claimed that these installations were 'colonies' and it was the Navy's job to defend them. The Act was Parliament's response, stating that taking goods from a human being is piracy, but if the owner or some living representative of theirs is not present in system, taking those goods is a legal salvage operation. The point was to keep the Navy from being obligated to defend every equipment cache or abandoned station in the galaxy. But by the same law, those Navy Thea Drones become abandoned goods the moment their motherships leave the system."`
 				goto response
 			
-			Label what
+			label what
 			`	"It's the act that declares all unmanned drones and stations to be legal salvage as long as their owner or owning body has no manned prescience in the system." She catches her breath, "It's the thing that makes this legal. I need you to attack and salvage a Thea Drone, rip out its scanner, and come back here."`
 				goto response
 				
@@ -2074,9 +2074,9 @@ mission "Defend Sabik"
 			`	He is carrying an identity chip. "Would you like to do the honors of installing this on your ship?"`
 			choice
 				`	"Sure."`
-					goto chip
+					#goto chip Where is the chip label?
 				`	"Too late to back out now, I guess."`
-					goto chip.
+					#goto chip. Same as with above. Should it be paint?
 				`	"Me being officially a just a merchant could serve us well."`
 				`	"I can't just keep flying merchant colors?"`
 			
@@ -2687,8 +2687,8 @@ mission "FW Syndicate Diplomacy 1D"
 			
 			label threat
 			choice
-			`	"What sort of threat?"`
-				goto story
+				`	"What sort of threat?"`
+					goto story
 			
 			label story
 			`	"Our world was enslaved for nearly a decade," she says. "Most of my childhood. We had been little more than an anarchist colony ourselves before that, though, so the Republic did nothing to aid us. Until the Disappearance."`
@@ -2838,15 +2838,15 @@ mission "FW Hope Recon 1D"
 				`	"Well, I'd rather not give them any advantage, no matter how slight."`
 					goto attack
 			
-			label pinguins
+			label penguins
 			`	Freya groans. "What is it with people thinking there will be penguins on Hope?"`
 			choice
-			`	"You know the ice and, well, nevermind."`
-				goto next
-			`	"You have a point."`
-				goto next
-			`	"Ok but what if there were and I missed them? I need to go back!"`
-				goto attack
+				`	"You know the ice and, well, nevermind."`
+					goto next
+				`	"You have a point."`
+					goto next
+				`	"Ok but what if there were and I missed them? I need to go back!"`
+					goto attack
 			label next
 			`	"Good," says Freya, "because I've got a much more interesting job for you to do next. The people at Kraz Cybernetics have a new toy they want to test out, and I volunteered you to help out. They're waiting for you on Rust, in the Kraz system."`
 				decline
@@ -3873,11 +3873,11 @@ mission "FW Pirates 4.1"
 			`	"And how did that work out?" says the old man. "How long after the battle did it take you to realize that we have no way of holding on to the planet you conquered?"`
 			choice
 				`	"I was almost immediately beaten over the head by this fact."`
-					goto sentance
+					goto sentence
 				`	"Not long."`
 					goto sentence
 				`	"I still believe it was the correct tactical choice, even if we can't hold the planet."`
-					goto sentance
+					goto sentence
 
 			label hero
 			`	"Indeed," says the senator. "And I bet it wasn't long after the battle that you realized saving the galaxy isn't that easy."`
@@ -5066,13 +5066,13 @@ mission "FW Alphas 1.1"
 					goto hold
 
 			label shoot
-			branch "hit" "shoot"
+			branch "hit" "miss"
 				has "gunslinger" >= 1
 
 			label hit
 			`	You quickly draw your weapon on reflex, but as you pull the trigger it leaps again. You manage to land a hit on its leg, which stuns the creature for long enough that Commander Nguyen can easily climb onto a nearby dumpster and leap into the air. He manages to grab the creature by the same leg as it soars past.`
 				goto pin
-			label shoot
+			label miss
 			`	You open fire, but it is leaping back and forth so fast that it is almost impossible to hit. But then you see Commander Nguyen climb onto a nearby dumpster and leap into the air, managing to grab the creature by the leg as it flies by.`
 				goto pin
 			label grab

--- a/data/story free worlds.txt
+++ b/data/story free worlds.txt
@@ -43,7 +43,7 @@ mission "Pact Recon 0"
 					goto warship
 
 			label warship
-			`	"You might need one if we can't get a handle on these pirate attacks." The Militia captain replies. "Hey, have you ever considered volunteering for the Southern Mutual Defense Pact?"
+			`	"You might need one if we can't get a handle on these pirate attacks." The Militia captain replies. "Hey, have you ever considered volunteering for the Southern Mutual Defense Pact?"`
 			choice
 				`	"Maybe if I knew what it was."`
 					goto smdp
@@ -68,7 +68,7 @@ mission "Pact Recon 0"
 			`	"You don't have to fight anyone, don't worry." She says, reassuringly. "If you're interested, the Pact is launching a new initiative, called 'Thousand Eyes'; we're asking ship captains to let us access their scanner logs, basically using merchants as a surveillance network. All you have to do is let us know if you see any pirates. Can we count on you to do your part?"`
 			choice
 				`	"Absolutely, sign me up."`
-				`	"I think I'll just head back to Republic space, I don't mess around with pirates."
+				`	"I think I'll just head back to Republic space, I don't mess around with pirates."`
 					decline
 			`	"That's the spirit!" She says."Right now, we need more eyes on a few systems on the edge of Southern space. All you need to do is fly through those systems, then report to our base on Glaze. I'll mark the target systems on your map."`
 					accept
@@ -213,11 +213,11 @@ mission "Pact Questioning"
 			goto ask
 		label ask
 			`	"Thank you," he says. "Am I correct that you performed some missions for the Southern Defense Pact, this would be before they declared themselves the Free Worlds`."`
-			`	"I've done some work here and there."
+			`	"I've done some work here and there."`
 			goto easy
 		label business
-			`	The officer's expression does not change. "I'm going to level with you, I already know what I need to know, but I have some paperwork that needs filled out. So you can either make this easy on both of us, or I can ground your ship while I subpoena your records."
-			`	"I've done a little work for them here and there." You admit.
+			`	The officer's expression does not change. "I'm going to level with you, I already know what I need to know, but I have some paperwork that needs filled out. So you can either make this easy on both of us, or I can ground your ship while I subpoena your records."`
+			`	"I've done a little work for them here and there." You admit.`
 				goto easy
 		label easy
 			`	"Tell me," he says, "was there someone who you reported to every time, or was it someone different every time?" As he is speaking, you again search him over for any indentifiers on his uniform. The Navy personell you have encountered in the past have a name badge on their lapel and rank insignia on their collar, but his uniform is entirely blank, save the eye on his lapel that has been staring you down the entire conversation.`
@@ -229,7 +229,7 @@ mission "Pact Questioning"
 		label account	
 			`	"Always the same with you merchants, isn't it?" He complains. "Would five grand effectively jog your memory?"`
 			choice
-			`	"I wish, but I honestly don't remember."
+			`	"I wish, but I honestly don't remember."`
 			goto wish
 			`	"My memory, no. But my bank account seems to remember one Freya Winters."`
 			goto freya
@@ -250,12 +250,12 @@ mission "Pact Questioning"
 		label recon
 			`	If your response was meant to be funny, he doesn't laugh. "Are you certain your reconnaissance was only targeted at pirates?" he asks. "Did they collect only your logs on pirate ships, or on every ship you saw?"`
 			choice
-			`	"No idea, I handed over all my sensor logs for the area, what they did with them is their problem."
+			`	"No idea, I handed over all my sensor logs for the area, what they did with them is their problem."`
 			label problem
 			`	"Just the pirate ships, not much else in the areas I was sent to. Do you want the same information so maybe the Navy can do their job?"`
 			label job
 		label problem
-			`	"So it would appear." He replies. "No further questions then, thank you for your time." And with that, he walks away, leaving you wondering what sort of trouble you have gotten yourself into.
+			`	"So it would appear." He replies. "No further questions then, thank you for your time." And with that, he walks away, leaving you wondering what sort of trouble you have gotten yourself into.`
 			decline
 		label job
 			`	"That wont be necessary." He replies coldly. "You're free to go for now, but I'll be in touch if I have any further questions." This last part sounds a bit like a threat, but you decide not to comment and instead take your leave, occasionally glancing back over your shoulder as you do to confirm you aren't being watched or followed. Of either, you're unsure.`
@@ -329,7 +329,7 @@ mission "FW Recon 1"
 			choice
 				`	"Sure, I'll be back in time for happy hour."`
 					accept
-				`	"What's the worst that could happen?
+				`	"What's the worst that could happen?`
 					accept
 				`	"I just came here on my lunch break. Boss doesn't like me talking with the locals. Says they offer dangerous jobs."`
 					decline
@@ -359,7 +359,7 @@ mission "FW Recon 1"
 			`	He pauses, then adds, "They pay me a thousand credits every time I say that."`
 				goto close
 			label dude
-			`	"Maybe catch me after happy hour and I'll give you a proper tour." He winks, and its tempting to take him up on that.
+			`	"Maybe catch me after happy hour and I'll give you a proper tour." He winks, and its tempting to take him up on that.`
 				goto close
 			label close
 			`	You cut the commlink, relieved that it was that easy.`
@@ -668,7 +668,7 @@ mission "FW Katya 1C"
 					goto illegal
 				`	"I've never seen those crates before in my life. I don't know where they came from."`
 					goto denial
-				`	"Not really, no."
+				`	"Not really, no."`
 					goto denial
 			
 			label medical
@@ -695,7 +695,7 @@ mission "FW Katya 1C"
 					goto karen
 				`	"Since when has the Republic gotten so heavy handed about searching civilian ships?"`
 					goto angry
-				`	"I'm just happy you didn't shoot me."
+				`	"I'm just happy you didn't shoot me."`
 					goto shoot
 	
 			label gracious
@@ -769,7 +769,7 @@ mission "FW Katya Alt 2"
 					decline
 				`	"Ok the free worlds is starting to sound like a bad spy movie. I'm out."`
 					decline
-				`	(Do a mock karate stance and steriotypical shout, flail your arms in a chopping manner, then walk away.)
+				`	(Do a mock karate stance and steriotypical shout, flail your arms in a chopping manner, then walk away.)`
 					decline
 	
 	on complete
@@ -832,7 +832,7 @@ mission "FW Katya 2B"
 					goto dumb
 
 			label dumb
-			`	The man presses the button to close the hatch. "I'm dressed fine, thank you."
+			`	The man presses the button to close the hatch. "I'm dressed fine, thank you."`
 				goto name
 				
 			label weapon
@@ -964,9 +964,9 @@ mission "FW Katya 3"
 			choice
 				`	"Yup. That makes perfect sense to me."`
 					goto agree
-				`	"Kill drone, rip out guts, bring guts back. Simple."
+				`	"Kill drone, rip out guts, bring guts back. Simple."`
 					goto agree
-				`	"Legal piracy? I'm in."
+				`	"Legal piracy? I'm in."`
 					goto agree
 				`	"A suicide mission? Pass."`
 					goto disagree
@@ -1083,7 +1083,7 @@ mission "FW Katya 5"
 					accept
 				`	"If it pays."`
 					accept
-				`	"Anything for the cause!"'
+				`	"Anything for the cause!"`
 				`	"You guys have interesting friends. How do you know these monks?"`
 					goto friends
 				`	"Sounds boring. Can't we go shoot down more Thea Drones instead?"`
@@ -1471,7 +1471,7 @@ mission "FW Escort 1"
 				`	"Sorry, I'm busy with another mission at this moment."`
 					defer
 			label ship
-			`	"I would call it target saturation, but that scares off potential pilots. Are you in or what?"
+			`	"I would call it target saturation, but that scares off potential pilots. Are you in or what?"`
 			choice
 				`	"I'm in"`
 					goto accept
@@ -2344,7 +2344,7 @@ mission "Liberate Kornephoros"
 					goto quiet
 				`	"The battle was brutal. I hope we don't have to keep doing that."`
 					goto brutal
-				`	"They are obviously mad that they lost, and I hope we can avoid further bloodshed."
+				`	"They are obviously mad that they lost, and I hope we can avoid further bloodshed."`
 					goto brutal
 					
 			label quiet
@@ -3429,8 +3429,8 @@ mission "FW Pirates 2"
 			`	He frowns. "Negotiate with criminals?"`
 			choice
 				`	"I'm told that only a small portion of the people on those worlds actually engage in piracy," you say, "and many of them are children pressed into service as crew members."`
-				`	"Most pirates are slaves. They don't deserve to be killed, they deserve to be freed."
-				`	"These so-called pirate worlds are just anarchist worlds. Their people pose no threat to us."
+				`	"Most pirates are slaves. They don't deserve to be killed, they deserve to be freed."`
+				`	"These so-called pirate worlds are just anarchist worlds. Their people pose no threat to us."`
 			`	"That may be," he says, "but their leaders are dangerous criminals, perhaps even more dangerous than the Navy, because they have no honor or morality. And every anarchist world is a possible haven for other lawless individuals. Including any of the Alphas who are still in hiding. So I say, we need to capture and control those worlds."`
 			label next
 			`	"This is all a tangent, though." he states. "In the meantime, I've got a related mission for you. While the Senate is deliberating, I'd like you to lead a patrol through our systems in the southern rim, to keep up enough of a presence to hold the pirates at bay. Once you've finished patrolling, bring the fleet back to <planet>. By then I should be back there, and we'll discuss our next steps. Well, get on it."`
@@ -4086,7 +4086,7 @@ mission "FW Diplomacy 1C"
 					goto fight
 				`	"Maybe they're afraid of the precedent it would set if they give in to us."`
 					goto precedent
-				`	"The Dirt Belt is a huge supplier of food and resources to the Republic. Why wouldn't they fight to hold onto it?"
+				`	"The Dirt Belt is a huge supplier of food and resources to the Republic. Why wouldn't they fight to hold onto it?"`
 					goto resources
 			label fight
 			`	"That's right," he says. "Amazing how heedless they can be, sitting in their comfy Parliament house deciding the fates of others."`
@@ -4273,7 +4273,7 @@ mission "FW Southern Battle 2"
 			`	"The fleet from Southbound Shipyards will be traveling with you," she says. "Other fleets with other commanders will be converging on Rastaban separately, at approximately the same time. So, you have no time to lose. You must travel directly to Rastaban from here, or else you will arrive too late to join in the fight. Good luck, captain."`
 				accept
 			label behemoths
-			`	"They're a part of the logistics fleet under my command." Freya shrugs, "I put out word that I needed some combat capable ships to help screen against missiles and torpedoes, and these crews heroically volunteered to keep you alive. Now hurry up, the you're on a time limit!"
+			`	"They're a part of the logistics fleet under my command." Freya shrugs, "I put out word that I needed some combat capable ships to help screen against missiles and torpedoes, and these crews heroically volunteered to keep you alive. Now hurry up, the you're on a time limit!"`
 				accept
 	npc
 		government "Free Worlds"
@@ -4665,7 +4665,7 @@ mission "FW Northern 2"
 				`	"Is everything okay?"`
 				`	"Did they agree to join us?"`
 				`	"Are you alright?"`
-				`	"Progress has been made this day."
+				`	"Progress has been made this day."`
 			`	"Yes, yes, of course," he says. "But taking on six more worlds all of a sudden - I just hope it's not more than we can handle. When the Navy recovers from the battle at Rastaban and strikes back, now we have much less idea where that strike will fall."`
 			`	"We need to move more of our fleet up here to the front," he says, "but I'd be willing to bet that the Navy has installed surveillance equipment on Hope, and maybe a few other planets in this sector too. Which I should have thought of before, because in order to be sure we've tracked every last one down, we need Freya's expertise in signals and sensors. So, I'm sending you to meet up with her on Dancer."`
 			choice
@@ -5069,8 +5069,8 @@ mission "FW Alphas 1.1"
 			branch "hit" "shoot"
 				has "gunslinger" >= 1
 
-            label hit
-            `    You quickly draw your weapon on reflex, but as you pull the trigger it leaps again. You manage to land a hit on its leg, which stuns the creature for long enough that Commander Nguyen can easily climb onto a nearby dumpster and leap into the air. He manages to grab the creature by the same leg as it soars past.`
+			label hit
+			`	You quickly draw your weapon on reflex, but as you pull the trigger it leaps again. You manage to land a hit on its leg, which stuns the creature for long enough that Commander Nguyen can easily climb onto a nearby dumpster and leap into the air. He manages to grab the creature by the same leg as it soars past.`
 				goto pin
 			label shoot
 			`	You open fire, but it is leaping back and forth so fast that it is almost impossible to hit. But then you see Commander Nguyen climb onto a nearby dumpster and leap into the air, managing to grab the creature by the leg as it flies by.`
@@ -5089,7 +5089,7 @@ mission "FW Alphas 1.1"
 					goto kill
 				`	(Let the Navy troops deal with this.)`
 					goto navy
-				`	(Listen to and question it.)
+				`	(Listen to and question it.)`
 					goto listen
 			label listen
 			`	You don't get a chance to ask it anything, and its shouts become unintelligible as the Navy forces surrounded it.`
@@ -5572,7 +5572,7 @@ mission "FW Albatross 1"
 			choice
 				`	"Wait, doesn't Alondo usually handle the diplomacy?"`
 					goto locals
-				`	"Whatever you say, boss."
+				`	"Whatever you say, boss."`
 					accept
 			label locals
 			`	"Usually, yes," she says. "But the locals on Albatross specifically asked for JJ. They're a very traditional population, and JJ is well-known as both a family man and a brave soldier. Whereas Alondo is... Alondo."`
@@ -5588,7 +5588,7 @@ mission "FW Albatross 1"
 					goto metoo
 				`	"Alondo's husband is a troublemaker by Anarchist standards? I've got to meet him sometime!"`
 					goto trouble
-				`	"Wait, people have problems with who other people love? That's weird."
+				`	"Wait, people have problems with who other people love? That's weird."`
 			`	"Yes," she says. "Yes, it is. That's cults for you, though. Now, let's go meet up with JJ."`
 				accept
 			label trouble
@@ -5796,7 +5796,7 @@ mission "FW Rand 1B"
 			`	"I was afraid of this," says JJ, "but I didn't think it would happen so quickly. I wonder if they knew that these new worlds were joining us, and deliberately used them as a diversion."`
 			choice
 				`	"What do we do now?"`
-				`	"We strike back now, right?"
+				`	"We strike back now, right?"`
 			`	JJ says, "Freya, you said part of our fleet fled to Tarazed?"`
 			`	"Yes," she says. "Probably not a strong enough fleet to drive them off, though."`
 			`	"Well, I guess we should regroup with them," he says. "Hopefully then we can plan a coordinated strike. Or if necessary, we can abandon this sector and get our fleet back to the Rim without losing too many ships. Councilor <last>, can you take us to <destination>?"`
@@ -7321,7 +7321,7 @@ mission "FW Pug 2B"
 			label deal
 			`	"Hold on," says Alondo, "I have one condition to add. You will give us one of your jump drives immediately. We will install it in our ship and verify that you are telling the truth about the Pug. If you are, we will work together until this threat is dealt with... and once it is dealt with, we will return our attention to bringing every member of the Syndicate who had a hand in those terrorist attacks to justice. That is our best and final offer." You nod in agreement.`
 			`	It's clear that Alastair is none too happy about that deal, and is unable to accept it. "The jump drives are extremely volitile, the one we have is the one we need to harvest more," he says. "Our Systems division is trying to discover the secret behind them so we could put them in mass production, with little success. If you simply give us some time, we will have a spare jump drive for your ship."`
-			`	Alondo is clearly displeased with this idea, but begrudgingly accepts he will not be able to force this situation. "I guess we'll wait, but be quick about it."
+			`	Alondo is clearly displeased with this idea, but begrudgingly accepts he will not be able to force this situation. "I guess we'll wait, but be quick about it."`
 				accept
 	on complete
 		set "FW Rec Ending"
@@ -7332,7 +7332,7 @@ mission "ESCW FW Rec End"
 	to fail
 		has "FW Check Ending"
 	on offer
-		log `With the alien invasion, the civil war is over for all intents and purposes. It will take some time for the Syndicate to muster the necissary jump drives so that we can repell this invasion."
+		log `With the alien invasion, the civil war is over for all intents and purposes. It will take some time for the Syndicate to muster the necissary jump drives so that we can repell this invasion."`
 		dialog `You have reached one of the endings of Endless Sky Civil War, but the story is not yet over. Our first planned (free) expansion "Invasion" will be out relatively soon. Until then, feel free to experiment with the different endings. Side with different factions, make different choices.`
 
 		
@@ -7403,7 +7403,7 @@ mission "FWC Attack Kaus Borealis"
 				goto battle
 			label battle
 			choice
-				`	"No need for me to imagine their perspective, I share it. I signed up to prove the Free World's innocence, not fight."
+				`	"No need for me to imagine their perspective, I share it. I signed up to prove the Free World's innocence, not fight."`
 					goto diplomacy
 				`	"Well, we can't exactly conquer the Republic. Shouldn't we try diplomacy?"`
 					goto diplomacy
@@ -7532,7 +7532,7 @@ mission "FWC Cebalrai 1"
 				`	"After knowing that we are using N-bombs, I can't continue to be a party to this."`
 					goto defect
 			label defect
-			`	Tomek winces at your words, "This will stay between us, my friend. If you are going to leave our cause, now would be the time to do so before anyone tries to stop you. But you had best make sure this is what you want to do."
+			`	Tomek winces at your words, "This will stay between us, my friend. If you are going to leave our cause, now would be the time to do so before anyone tries to stop you. But you had best make sure this is what you want to do."`
 			choice
 				`	"I guess I'll continue helping the cause. What do we do now?"`
 					goto end

--- a/data/story free worlds.txt
+++ b/data/story free worlds.txt
@@ -5891,40 +5891,40 @@ mission "FW Defend New Tibet"
 		conversation
 			`The fleet in orbit around Wayfarer is pitifully small, surely not enough to take on more than a couple of Navy capital ships. JJ orders one of their communication officers to try to establish a secure link to Bourne or to any Free Worlds post on the other side of the Navy blockade. After about ten minutes, the officer returns and says, "Sir, we're receiving communications from New Tibet. You need to talk to them."`
 			`	"Our fleet is there?" asks JJ.`
-			`	"No sir, the Syndicate. They're under attack by the Syndicate."`
+			`	"No sir, the Syndicate. They're under siege by the Syndicate."`
 			`	"What?" says JJ. He rushes into the communication room, and you and Freya follow. On the video screen is a Buddhist monk in a maroon robe; behind him, you see other monks rushing about with none of the serenity you would usually expect of them. "What's going on there?" asks JJ.`
-			`	The monk explains, "Yesterday a Syndicate ship landed near our monastery, and the pilot sought refuge with us. He brings evidence that the Syndicate, or some faction within the Syndicate, was behind the attacks on Geminus and Martini."`
+			`	The monk explains, "Yesterday a Syndicate ship landed near our monastery, and the pilot sought sanctuary with us. He brings evidence that the Syndicate, or some faction within the Syndicate, was behind the attacks on Geminus and Martini."`
 			choice
 				`	"Why would the Syndicate do that?"`
 				`	"What sort of evidence?"`
 					goto evidence
 			`	"He claims that a certain faction within the Syndicate values economic growth above all else," says the monk, "and incited this war for that reason."`
 			`	"That's insane," says Freya.`
-			`	"But not completely implausible," says JJ.`
+			`	"But not completely implausible," adds JJ.`
 			label evidence
-			`	The monk says, "He brought a great deal of evidence. Plans for several nuclear devices. Data from underground testing of high yeild versions. A manufactured bomb casing. Samples of fissile material. And he named the planet where the development was done: Mutiny, in the Gienah system. We hid his ship in a cave. A day later, a Syndicate fleet appeared in orbit. They do not know where the defector landed, but they say they will destroy whatever settlement is harboring him unless he is returned to them immediately."`
+			`	The monk says, "He brought a great deal of evidence. Plans for several nuclear devices, including N-Bombs. Data from underground testing of versions designed to destroy shipyards. A manufactured bomb casing of some sort. Samples of some material. On top of it all, he named the planet where the development was done: Mutiny, in the Gienah system. We hid his ship in a cave. A day later, a Syndicate fleet appeared in orbit. They do not know where the he landed, but they claim to be seeking justice. They claim that if we turn the defector over, they will pledge their forces to the Free Worlds. However, I fear they are insincere, and if we reveal ourselves they may want to silence any witnesses."`
 			`	After a moment, JJ says, "If these allegations are true, if we can prove that the Free Worlds was innocent of any involvement in those attacks, the Republic might make peace with us, or at least agree to a ceasefire. I vote that we try to shelter this defector and hear his story."`
-			`	"And if it's a lie," says Freya, "and we refuse the Syndicate's demands, we lose our only ally. And many civilians will be killed, as well. I care about justice, but trading a definite ally for a slim possibility of peace: that is an unwise investment. I vote that we hand this man over to the Syndicate."`
+			`	"And if it's a lie," says Freya, "and we refuse the Syndicate's demands, we lose our primary supply chain. Many civilians will be killed as well. I care about justice, but trading the resources we need to stay in the fight for a slim possibility of peace? That is a trade we have taken in the past, and yet we are still at war. I vote we stay the course, and trade this man to remain in the good graces Syndicate."`
 			`	The monk says, "We want to see justice done, and peace prevail. If you ask us to, we will flee to the mountains and take refuge until help arrives."`
 			`	As the third Council member present, you have the deciding vote, and the entire course of this war may rest on your decision.`
 			choice
-				`	"I say we rescue the defector, even if it means war with the Syndicate."`
+				`	"I say we meet with the whistleblower and hear him out before we make a decision."`
 					goto rescue
-				`	"I say we hand the defector over to the Syndicate, and focus on winning the battle against the Republic."`
+				`	"I say we hand the defector over to the Syndicate, their resources will be invaluable in holding back the Republic."`
 					goto surrender
 			label rescue
 			`	"Are you sure?" asks Freya. "A lot of lives hang in the balance."`
 			choice
-				`	"Yes, I'm sure. We rescue the defector."`
+				`	"Yes, I'm sure. We rescue the whistleblower."`
 					goto "definitely rescue"
 				`	"Fine, we'll hand him over. But I don't think it's the right thing to do."`
 					goto "definitely surrender"
 			label surrender
 			`	"If Katya were here," says JJ, "she would tell us to choose justice over political expedience."`
 			choice
-				`	"Well, she's not here, and I say we can't afford to lose the Syndicate as an ally."`
+				`	"We're at war here. We can't pass up this opportunity for fresh forces and ships."`
 					goto "definitely surrender"
-				`	"I suppose you're right. Let's mount a rescue operation."`
+				`	"I suppose you're right. We can at least meet with the whistleblower and hear him out."`
 					goto "definitely rescue"
 			
 			label "definitely surrender"
@@ -5934,7 +5934,7 @@ mission "FW Defend New Tibet"
 				decline
 			
 			label "definitely rescue"
-			`	JJ seems very relieved at your choice. "I think that's the right choice, Captain," he says. "We can take the fleet we have here, sweep up north to avoid the thickest part of the Navy's occupying fleet, and cut over to New Tibet to drive the Syndicate ships away. Let's just hope these monks can stay hidden until then."`
+			`	JJ seems very relieved at your choice. "I think that's the right choice, Captain," he says. "I doubt the Syndicate forces will meet us with open arms, so we should take the fleet we have here. If we sweep up north to avoid the thickest part of the Navy's occupying fleet, and cut over to New Tibet, we should be able to meet with the whistleblower. Let's just hope the Syndicate is true to their word, and that we don't end up at war with them, too."`
 				accept
 	
 	on accept
@@ -7584,7 +7584,7 @@ mission "FWC Cebalrai 1B"
 			`You meet up with Tomek and Alondo and tell them that the defenses in the Cebalrai system did not seem particularly strong. "They must've seen the writing on the wall and pulled back the rest of their fleet," says Alondo.`
 			`	"Either that," says Tomek, "or they're wary of engaging us again now that they know we're willing to use nukes. Which I'm still not happy about, by the way. It's only a matter of time until they respond in kind. But in any case, our next move is clear: bring a fleet to Cebalrai and capture the system. <first>, you'll be in charge of that fleet. Alondo can travel with you to handle the diplomatic aftermath."`
 			`	"Before we go on," Alondo says, "you two should know that I just received word that Tarazed has decided to officially sever ties with us."`
-			`	Tomek looks rather somber before saying, "Bold move for a system we have completely surrounded. They're none of our concern right now. Let's make our way to Cebalrai."`
+			`	Tomek looks rather somber before saying, "They're none of our concern right now. Let's make our way to Cebalrai."`
 				accept
 	
 	on complete
@@ -7667,7 +7667,7 @@ mission "FWC Nuke Supply 1"
 				`	"Do you think we have any chance at a peace settlement?"`
 					goto peace
 			label destroy
-			`	"That would be an awful precedent," says Alondo, "perhaps worse than the fact we're using nukes. If civilian populations become a legitimate target, any of our worlds could be attacked at any time. And it's not like there's any way to defend a world from orbital bombardment. No one would ever be able to feel safe in their own homes again."`
+			`	"That would be an awful precedent," says Alondo, "perhaps worse than the fact we're using nukes. If civilian populations become a legitimate target, any of our worlds could be attacked at any time. And it's not like it's cheap or easy to defend a world from orbital bombardment. No one would ever be able to feel safe in their own homes again."`
 				goto next
 			label peace
 			`	"I hope so," says Alondo. "We'll let them keep shooting at us for a while, to vent their anger and let them prove their point. Then once they see the Navy isn't going to rescue them, we'll negotiate. That's really our only alternative. I do not want to be the person who authorizes the first attack on civilian targets since the dawn of the Republic."`
@@ -7757,7 +7757,7 @@ mission "FWC Nuke Supply 1C"
 	on offer
 		log "Delivered a load of enriched uranium to a warlord's fortress on Greenrock, in exchange for warheads for the Free Worlds to use against the Navy. Hopefully forming such a friendly relationship with dangerous criminals will not cause trouble for the Free Worlds in the future."
 		conversation
-			`You land at one of the many private fortresses on Greenrock owned by various competing warlords. Some workers unload the cargo from the Blue Yonder, and load it up with some lead-lined, well-padded crates that must contain nuclear warheads. You're not sure you like being a part of this, but it may be true that this is the only way you will stand a chance against the Navy.`
+			`You land at one of the many private fortresses on Greenrock owned by various competing warlords. Some workers unload the cargo from the Blue Yonder, and load it up with some lead-lined, well-padded crates that must contain nuclear warheads.`
 				accept
 	
 	npc accompany save
@@ -7880,10 +7880,13 @@ mission "FWC Diplomacy 1C"
 			`	Xao addresses the three of you. "We have heard your demands," he says, "and now, here is our response. Katerina Reynolds, Alondo Gruyere, and <first> <last>, you are hereby charged with treason and insurrection. Your trial will begin immediately."`
 			choice
 				`	"What? We were guaranteed safe passage!"`
-				`	"You will regret this! If you arrest us, the Free Worlds will retaliate against you."`
-			`	As you try to protest, Alondo speaks up. He is not shouting, but his voice carries over the murmur of other voices. "We have a ship in orbit. If we do not return--"`
+					#goto protest Commenting this out as this label does not yet exist
+				`	"Betrayal! We came here in good faith to negotiate peace."`
+					#goto protest
+				`	<Remain Silent>`
+			`	Alondo speaks up. He is not shouting, but his voice carries over the murmur of other voices. "We have a ship under the planetary shields. If we do not return--"`
 			`	Xao cuts him off. "Your ship is no threat to us. We have already verified that it carries no nuclear weapons or n-bombs, and this building's shielding and anti-missile systems are quite sufficient to defend against conventional weapons. And there is nothing in its cargo hold but ordinary, non-radioactive metals."`
-			`	Alondo says, "That's right. Tungsten, to be exact. Aerodynamic tungsten rods, each the size of a tree trunk, with a simple guidance system on one end. Our ship is in low earth orbit, traveling at a velocity of roughly eight kilometers per second." As he speaks, the Parliament chamber gradually grows very quiet. "So we will be returning to our ship," says Alondo, "with Miss Reynolds. If the ship in orbit does not hear from me every two minutes, it will jettison its cargo, and there will be nothing left of this building but a crater." He points to the watch he is wearing, and you realize that it must be some sort of communicator.`
+			`	Alondo says, "That's right. Tungsten, to be exact. Aerodynamic tungsten rods, each the size of a tree trunk, with a simple guidance system on one end. Our ship is in low earth orbit, traveling at a velocity of roughly eight kilometers per second." As he speaks, the Parliament chamber gradually grows very quiet. "So we will be returning to our ship," says Alondo, "with Miss Reynolds. If the ship in orbit does not hear from me every two minutes, it will jettison its cargo, and there will be nothing left of this building and it's surroundings but a rather large crater." He points to the watch he is wearing, and you realize that it must be some sort of communicator.`
 			`	After a brief whispered consultation with a few of the other members of Parliament, Xao says, "You will lose this war, and you will pay dearly for it. Guards, let them return to their ship." You hurry back to your ship and take off immediately, aware that as soon as you are out of range of Earth, the Navy will probably be more than willing to attack you.`
 				launch
 	
@@ -7944,7 +7947,7 @@ mission "FWC Checkmate 1"
 	on offer
 		event "fwc defend cebalrai"
 		conversation
-			`When you land on Tundra, Tomek seems glad to see Katya back, but you sense that he's also a little wary of how she will respond to the choices the Free Worlds have been making. "Using nukes, threatening orbital bombardment," says Katya, "treating the Syndicate as an ally. Anything else I missed while I was gone?"`
+			`When you land on Tundra, Tomek seems glad to see Katya back, he's also a little wary of how she will respond to the choices the Free Worlds have been making. "Using nukes, threatening orbital bombardment," says Katya, "treating the Syndicate as an ally. Anything else I missed while I was gone?"`
 			choice
 				`	"We only want this war to be over as soon as possible."`
 				`	"We've just been trying to avoid being destroyed by the Navy, and things have gotten a bit out of hand."`

--- a/data/story northern union.txt
+++ b/data/story northern union.txt
@@ -544,8 +544,8 @@ mission "Meeting an Alpha 2"
 
 	on complete
 		conversation
-		`	As you arrive in orbit above <destination>, Dylan presents you with a box. Inside it is a plasma pistol with "Lucky" scratched on the side.`
-		`	In her ever aggressive voice, Dylan says: "My master believes this gun will be of use to you on this quest. Meet me near the landing pad closest to the outfitter as soon as you make yourself inconspicuous. Now, go!"`
+			`	As you arrive in orbit above <destination>, Dylan presents you with a box. Inside it is a plasma pistol with "Lucky" scratched on the side.`
+			`	In her ever aggressive voice, Dylan says: "My master believes this gun will be of use to you on this quest. Meet me near the landing pad closest to the outfitter as soon as you make yourself inconspicuous. Now, go!"`
 
 mission "Meeting an Alpha 3"
 	name "Corporate Espionage"
@@ -561,26 +561,27 @@ mission "Meeting an Alpha 3"
 		"gunslinger" ++
 		outfit "Lucky" 1
 		conversation
-		`	After your routine walk around the spaceport, you wander off towards the landing pad closest to the outfitter. As you approach, you hear gunfire from various weapons.`
-		choice
-			`	(Investigate.)`
+			`	After your routine walk around the spaceport, you wander off towards the landing pad closest to the outfitter. As you approach, you hear gunfire from various weapons.`
+			choice
+				`	(Investigate.)`
 				goto investigate
-			`	(Stay put.)`
+				`	(Stay put.)`
 				goto stay
-			`	(Return to your ship.)`
+				`	(Return to your ship.)`
 				goto run
 			label investigate
 			`	As you approach, you hear Dylan shouting while exchanging fire with local security forces. You catch her shouting things like "Die for the Godlord, mortal scum!" while falling back.`
 			choice
-			`	(Use your fancy new sidearm, Lucky, to help her.)`
+				`	(Use your fancy new sidearm, Lucky, to help her.)`
 				goto help
-			`	(Return to your ship.)`
+				`	(Return to your ship.)`
 				goto run
 			label stay
 			`	You find cover and wait. The firefight slowly approaches you until it is eventually upon you. It's Dylan, taking on nearly the entire spaceport security team by herself.`
-			`	(Use your fancy new sidearm, Lucky, to help her.)`
+			choice
+				`	(Use your fancy new sidearm, Lucky, to help her.)`
 				goto help
-			`	(Return to your ship.)`
+				`	(Return to your ship.)`
 				goto run
 			label help
 			`	You draw Lucky and begin firing. Each squeeze of the trigger releases a satisfying and confusing amount of plasma bolts. Before long, you and Dylan have managed to completely suppress the securty forces pursuing her.`
@@ -739,18 +740,17 @@ mission "NU Bounty 2"
 				`	"Sneak in by loading ourselves into a crate."`
 					goto crate
 				`	"Just walk into the ship like we're part of the crew."`
-					goto crew
+					goto crewmember
 			
 			label assault
-			set
-				"gunslinger"++
+			"gunslinger"++
 			`	"A brilliant and unexpected tactic!" he exclaims, before laying down fire on the unsuspecting dock workers who are unloading cargo from the Leviathan. Being unarmed, innocent bystanders, they run at the first sign of violence. You find yourself in the cargo bay and consider your next move.`
 				goto cargo
 			label crate
 			`	"Captain, are you trying to get close to me? Because all you need to do is ask." He uncomfortably winks with one eye, then the other, before crawling into a crate barely big enough for the two of you. Before you get a chance to reconsider your options, he grabs you and pulls you in as well. As he shuts the lid, you catch a glimpse of the label, which reads "Bulkhead grinder." These tools are generally only used in decommissions and refits.`
 			`	An uncomfortable amount of time is spent in the cramped crate with this creepy bounty hunter. The two of you stare at each other in silence until eventually the dockworkers retrieve your crate and load it into the cargo bay. After some more time sitting in silence with this strange man and his cowboy hat, he opens the crate. You find yourselves in the cargo bay, just up the loading ramp from where you began.`
 				goto cargo
-			label crew
+			label crewmember
 			`	The two of you calmly walk up the ramp into the cargo bay. Neither the ship's crew nor the dock workers acknowledge your presence as you enter the cargo bay and consider your next move.`
 				goto cargo
 			
@@ -770,6 +770,7 @@ mission "NU Bounty 2"
 			apply
 				set "greedy bountyhunter"
 			`	You quickly look for anything small enough to pocket, or anything you can carry on your person that won't slow you down. You manage to find a backpack and a satchel. You have no time to investigate their contents, so you grab and wear them both. You still have to decide where to go next.`
+			choice
 				`	(To the Bridge!)`
 					goto bridge
 				`	(Ask a member of the crew where the captain is.)`
@@ -817,7 +818,6 @@ mission "NU Bounty 2B"
 	name "Wanted: Dead or Alive, Redemption"
 	description "Find and kill the <npc>, last seen near the Cardax system."
 	source
-		random < 40
 		near Arneb 1 20
 	destination "Haven"
 	to offer

--- a/data/story republic navy.txt
+++ b/data/story republic navy.txt
@@ -152,7 +152,7 @@ mission "Navy Scouting 1"
 		attributes "paradise"
 	destination "Chiron"
 	to offer
-		Has "event: war begins"
+		has "event: war begins"
 		not "chosen sides"
 		random < 60
 
@@ -196,7 +196,7 @@ mission "Navy Scouting 2"
 		not "chosen sides"	
 		random < 40
 
-		on offer
+	on offer
 		dialog
 			`You receive a message from Mulgrew, the Navy captain who asked you to fly through some uninhabited systems to the north: "I need some data from a few dead end systems," she says, "there's usually some pirate fleets in the area, but they can't pirate sensor logs. Interested?"`
 	
@@ -342,5 +342,5 @@ mission "Meeting an Alpha 2b"
 	on decline
 		payment 275000
 		log "Turned over Warlord Peg's communicator to the Republic. They say they'll call me if they need more information."
-		"pegs communicator: done"
+		set "pegs communicator: done"
 		"assisted republic" ++

--- a/data/story republic navy.txt
+++ b/data/story republic navy.txt
@@ -303,7 +303,7 @@ mission "Story Direction 1"
 			`	"It's a custom paint job," he states plainly: "I am very proud of the fact I have been chosen to be a full-time Republic contractor. The pay is amazing, and I'm serving my nation.`
 				goto contractor
 			label contractor
-			`	The man begins to walk away, then turns back: "You know, I wasn't selected by accident. I took the initiative, and investigated the Northern Union. Did some jobs for them, built up a network of contacts, then turned them all into the Republic. They offered me this job not long after. With these new 'Free Worlds' terrorists forming to the south, I'm sure you'll find opportunities to serve our great Republic if you play along with them a bit. You can also always do what I did: check out the worlds south of Kornephoros, or north of Alcyone and east of Almaaz. Pirates and terrorists are always desperate for fresh merchant faces to do their dirty work. Find a name and turn them in."
+			`	The man begins to walk away, then turns back: "You know, I wasn't selected by accident. I took the initiative, and investigated the Northern Union. Did some jobs for them, built up a network of contacts, then turned them all into the Republic. They offered me this job not long after. With these new 'Free Worlds' terrorists forming to the south, I'm sure you'll find opportunities to serve our great Republic if you play along with them a bit. You can also always do what I did: check out the worlds south of Kornephoros, or north of Alcyone and east of Almaaz. Pirates and terrorists are always desperate for fresh merchant faces to do their dirty work. Find a name and turn them in."`
 				accept
 
 mission "Meeting an Alpha 2b"

--- a/data/unique fleets.txt
+++ b/data/unique fleets.txt
@@ -33,7 +33,7 @@ mission "Sabik Fleet, plus Kornephoros"
 		ship "Sparrow" "F.S. Meteor"
 		ship "Sparrow" "F.S. Finch"
 	on complete
-	`	set "sf killed: done"
+		set "sf killed: done"
 
 mission "Sabik Fleet, no Kornephoros"
 	invisible
@@ -44,7 +44,7 @@ mission "Sabik Fleet, no Kornephoros"
 		and
 			has "kk killed: done"
 			has "capture of Kornephoros"
-Add to fail on this line
+#Add to fail on this line
 	npc kill
 		personality heroic staying plunders
 		government "Free Worlds"


### PR DESCRIPTION
Cleans up a large chunk of the errors, primarily ones from missions.

What it doesn't fix:
The wall of misc errors about "" outfits in ships
Missing outfit space in some ships
And in addition it doesn't touch any of the errors that come up only after a save file is created, meaning any errors from events aren't changed.

Also to share my thought: "I LOST THE CHIP TOMEK!" 
One of the errors came about from a missing label, that being the label chip. There is however, the label paint unused below it, so I am unsure if I should have changed it to that or fixed it how i did (which is effectively just telling the game that there is no label named chip).

Regardless, if you don't start up a save, all of the errors now fit in one terminal window(with scrolling), and the errors file is now down to 13.6 kB.