### PR TITLE
Port repositioning also as HOLD position bugfix.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1241,7 +1241,7 @@ bool AI::FollowOrders(Ship &ship, Command &command) const
 	// If your parent is jumping or absent, that overrides your orders unless
 	// your orders are to hold position.
 	shared_ptr<Ship> parent = ship.GetParent();
-	if(parent && type != Orders::HOLD_POSITION && type != Orders::MOVE_TO)
+	if(parent && type != Orders::HOLD_POSITION && type != Orders::HOLD_ACTIVE && type != Orders::MOVE_TO)
 	{
 		if(parent->GetSystem() != ship.GetSystem())
 			return false;
@@ -1258,9 +1258,9 @@ bool AI::FollowOrders(Ship &ship, Command &command) const
 		SelectRoute(ship, it->second.targetSystem);
 		return false;
 	}
-	else if(type == Orders::MOVE_TO && ship.Position().Distance(it->second.point) > 20.)
+	else if((type == Orders::MOVE_TO || type == Orders::HOLD_ACTIVE) && ship.Position().Distance(it->second.point) > 20.)
 		MoveTo(ship, command, it->second.point, Point(), 10., .1);
-	else if(type == Orders::HOLD_POSITION || type == Orders::MOVE_TO)
+	else if(type == Orders::HOLD_POSITION || type == Orders::HOLD_ACTIVE || type == Orders::MOVE_TO)
 	{
 		if(ship.Velocity().Length() > .001 || !ship.GetTargetShip())
 			Stop(ship, command);
@@ -3700,6 +3700,12 @@ void AI::IssueOrders(const PlayerInfo &player, const Orders &newOrders, const st
 		hasMismatch |= !orders.count(ship);
 		
 		Orders &existing = orders[ship];
+		// HOLD_ACTIVE cannot be given as manual order, but we make sure here
+		// that any HOLD_ACTIVE order also matches when an HOLD_POSITION
+		// command is given.
+		if(existing.type == Orders::HOLD_ACTIVE)
+			existing.type = Orders::HOLD_POSITION;
+		
 		hasMismatch |= (existing.type != newOrders.type);
 		hasMismatch |= (existing.target.lock().get() != newTarget);
 		existing = newOrders;
@@ -3746,7 +3752,7 @@ void AI::UpdateOrders(const Ship &ship)
 		return;
 	
 	Orders &order = it->second;
-	if(order.type == Orders::MOVE_TO && ship.GetSystem() == order.targetSystem)
+	if((order.type == Orders::MOVE_TO || order.type == Orders::HOLD_ACTIVE) && ship.GetSystem() == order.targetSystem)
 	{
 		// If nearly stopped on the desired point, switch to a HOLD_POSITION order.
 		if(ship.Position().Distance(order.point) < 20. && ship.Velocity().Length() < .001)
@@ -3754,8 +3760,8 @@ void AI::UpdateOrders(const Ship &ship)
 	}
 	else if(order.type == Orders::HOLD_POSITION && ship.Position().Distance(order.point) > 20.)
 	{
-		// If far from the defined target point, return via a MOVE_TO order.
-		order.type = Orders::MOVE_TO;
+		// If far from the defined target point, return via a HOLD_ACTIVE order.
+		order.type = Orders::HOLD_ACTIVE;
 		// Ensure the system reference is maintained.
 		order.targetSystem = ship.GetSystem();
 	}

--- a/source/AI.h
+++ b/source/AI.h
@@ -151,7 +151,10 @@ private:
 	class Orders {
 	public:
 		static const int HOLD_POSITION = 0x000;
-		static const int MOVE_TO = 0x001;
+		// Hold active is the same command as hold position, but it is given when a ship
+		// actively needs to move back to the position it was holding.
+		static const int HOLD_ACTIVE = 0x001;
+		static const int MOVE_TO = 0x002;
 		static const int KEEP_STATION = 0x100;
 		static const int GATHER = 0x101;
 		static const int ATTACK = 0x102;


### PR DESCRIPTION
**Bugfix:** This PR addresses an issue where the HOLD command doesn't toggle if ships are still moving to come to a stop.

## Fix Details
This is a port from an open bugfix on endless-sky:
https://github.com/endless-sky/endless-sky/pull/5040

See the original PR and commits for details.

This PR was briefly tested on ESCW/ESS and appears to function as intended.