### PR TITLE
This PR ports a feature where bays can get a custom facing-angle.

### DIFF
--- a/source/Angle.cpp
+++ b/source/Angle.cpp
@@ -125,6 +125,16 @@ Angle Angle::operator-() const
 
 
 
+bool Angle::operator==(const Angle &other) const
+{
+	// The angle is internally stored as an integer value between 0 and 2^16 - 1
+	// We can compare for equality using this very high precission by just comparing
+	// the internal values.
+	return angle==other.angle;
+}
+
+
+
 // Get a unit vector in the direction of this angle.
 Point Angle::Unit() const
 {

--- a/source/Angle.h
+++ b/source/Angle.h
@@ -46,6 +46,9 @@ public:
 	Angle &operator-=(const Angle &other);
 	Angle operator-() const;
 	
+	// Comparison operators
+	bool operator==(const Angle &other) const;
+	
 	// Get a unit vector in the direction of this angle.
 	Point Unit() const;
 	// Convert an Angle object to degrees, in the range -180 to 180.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -272,7 +272,7 @@ void Ship::Load(const DataNode &node)
 						bay.side = j;
 				for(unsigned j = 1; j < BAY_FACING.size(); ++j)
 					if(child.Token(i) == BAY_FACING[j])
-						bay.facing = j;
+						bay.facing = BAY_ANGLE[j];
 			}
 			if(child.HasChildren())
 				for(const DataNode &grand : child)
@@ -284,8 +284,26 @@ void Ship::Load(const DataNode &node)
 						const Effect *e = GameData::Effects().Get(grand.Token(1));
 						bay.launchEffects.insert(bay.launchEffects.end(), count, e);
 					}
+					else if(grand.Token(0) == "angle" && grand.Size() >= 2)
+						bay.facing = Angle(grand.Value(1));
 					else
-						grand.PrintTrace("Child nodes of \"bay\" tokens can only be \"launch effect\":");
+					{
+						bool handled = false;
+						for(unsigned i = 1; i < BAY_SIDE.size(); ++i)
+							if(grand.Token(0) == BAY_SIDE[i])
+							{
+								bay.side = i;
+								handled = true;
+							}
+						for(unsigned i = 1; i < BAY_FACING.size(); ++i)
+							if(grand.Token(0) == BAY_FACING[i])
+							{
+								bay.facing = BAY_ANGLE[i];
+								handled = true;
+							}
+						if(!handled)
+							grand.PrintTrace("Child nodes of \"bay\" tokens can only be \"launch effect\", angle-keywords or facing keywords:");
+					}
 				}
 		}
 		else if(key == "leak" && child.Size() >= 2)
@@ -726,18 +744,26 @@ void Ship::Save(DataWriter &out) const
 		{
 			double x = 2. * bay.point.X();
 			double y = 2. * bay.point.Y();
-			if(bay.side && bay.facing)
-				out.Write(BAY_TYPE[bay.isFighter], x, y, BAY_SIDE[bay.side], BAY_FACING[bay.facing]);
+			int facing_name_index = 0;
+			for(unsigned i = 1; i < BAY_FACING.size(); ++i)
+				if(bay.facing == BAY_ANGLE[i])
+					facing_name_index = i;
+			
+			if(bay.side && facing_name_index)
+				out.Write(BAY_TYPE[bay.isFighter], x, y, BAY_SIDE[bay.side], BAY_FACING[facing_name_index]);
 			else if(bay.side)
 				out.Write(BAY_TYPE[bay.isFighter], x, y, BAY_SIDE[bay.side]);
-			else if(bay.facing)
-				out.Write(BAY_TYPE[bay.isFighter], x, y, BAY_FACING[bay.facing]);
+			else if(facing_name_index)
+				out.Write(BAY_TYPE[bay.isFighter], x, y, BAY_FACING[facing_name_index]);
 			else
 				out.Write(BAY_TYPE[bay.isFighter], x, y);
-			if(!bay.launchEffects.empty())
+			bool writeFacing = !facing_name_index && bay.facing.Degrees();
+			if(!bay.launchEffects.empty() || writeFacing)
 			{
 				out.BeginChild();
 				{
+					if(writeFacing)
+						out.Write("angle", bay.facing.Degrees());
 					for(const Effect *effect : bay.launchEffects)
 						out.Write("launch effect", effect->Name());
 				}
@@ -1877,7 +1903,7 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships, vector<Visual> &visuals)
 			double maxV = bay.ship->MaxVelocity() * (1 + bay.ship->IsDestroyed());
 			Point exitPoint = position + angle.Rotate(bay.point);
 			// When ejected, ships depart haphazardly.
-			Angle launchAngle = ejecting ? Angle(exitPoint - position) : angle + BAY_ANGLE[bay.facing];
+			Angle launchAngle = ejecting ? Angle(exitPoint - position) : angle + bay.facing;
 			Point v = velocity + (.3 * maxV) * launchAngle.Unit() + (.2 * maxV) * Angle::Random().Unit();
 			bay.ship->Place(exitPoint, v, launchAngle);
 			bay.ship->SetSystem(currentSystem);
@@ -2974,7 +3000,7 @@ bool Ship::PositionFighters() const
 			hasVisible = true;
 			bay.ship->position = angle.Rotate(bay.point) * Zoom() + position;
 			bay.ship->velocity = velocity;
-			bay.ship->angle = angle + BAY_ANGLE[bay.facing];
+			bay.ship->angle = angle + bay.facing;
 			bay.ship->zoom = zoom;
 		}
 	return hasVisible;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -71,11 +71,8 @@ public:
 		static const uint8_t OVER = 1;
 		static const uint8_t UNDER = 2;
 		
-		uint8_t facing = 0;
-		static const uint8_t FORWARD = 0;
-		static const uint8_t LEFT = 1;
-		static const uint8_t RIGHT = 2;
-		static const uint8_t BACK = 3;
+		// The angle this bay is facing relative to the carrying ship.
+		Angle facing = 0;
 		
 		// The launch effect(s) to be simultaneously played when the bay's ship launches.
 		std::vector<const Effect *> launchEffects;


### PR DESCRIPTION
## Feature Details
Bays can get any angle after this PR, instead of just the default forward, left, right and back only.

## UI Screenshots
Screenshots and details can be found in the original PR at https://github.com/endless-sky/endless-sky/pull/4749.

## Usage Examples
The savegame provided in https://github.com/endless-sky/endless-sky/pull/4749 also appears to work for the current version of ES-Stories to test this feature.