### PR TITLE
Deploy and recall only selected fighters instead of all

### DIFF
--- a/source/AI.h
+++ b/source/AI.h
@@ -94,7 +94,7 @@ private:
 	void MoveEscort(Ship &ship, Command &command);
 	static void Refuel(Ship &ship, Command &command);
 	static bool CanRefuel(const Ship &ship, const StellarObject *target);
-	bool ShouldDock(const Ship &ship, const Ship &parent, bool playerShipsLaunch) const;
+	bool ShouldDock(const Ship &ship, const Ship &parent, const System *playerSystem) const;
 	
 	// Methods of moving from the current position to a desired position / orientation.
 	static double TurnBackward(const Ship &ship);
@@ -177,6 +177,7 @@ private:
 
 
 private:
+	void IssueDeploy(const PlayerInfo &player);
 	void IssueOrders(const PlayerInfo &player, const Orders &newOrders, const std::string &description);
 	// Convert order types based on fulfillment status.
 	void UpdateOrders(const Ship &ship);
@@ -195,7 +196,6 @@ private:
 	// Command applied by the player's "autopilot."
 	Command autoPilot;
 	
-	bool isLaunching = false;
 	bool isCloaking = false;
 	
 	bool escortsAreFrugal = true;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2203,6 +2203,21 @@ bool Ship::IsLanding() const
 
 
 
+
+bool Ship::IsDeploying() const
+{
+	return doDeploy;
+}
+
+
+
+void Ship::DoDeploy(bool shouldDeploy)
+{
+	doDeploy = shouldDeploy;
+}
+
+
+
 // Check if this ship is currently able to begin landing on its target.
 bool Ship::CanLand() const
 {

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -209,6 +209,9 @@ public:
 	bool IsDisabled() const;
 	bool IsBoarding() const;
 	bool IsLanding() const;
+	bool IsDeploying() const;
+	// Set if this ship should be deploying
+	void DoDeploy(bool shouldDeploy);
 	// Check if this ship is currently able to begin landing on its target.
 	bool CanLand() const;
 	// Check if some condition is keeping this ship from acting. (That is, it is
@@ -435,6 +438,10 @@ private:
 	
 	int forget = 0;
 	bool isInSystem = true;
+	// Variable that indicates if this ship should deploy. Only relevant for
+	// carried ships. This variable is not combined with the Commands in AI
+	// since it is possible that a ship has both a deploy and orders.
+	bool doDeploy = false;
 	// "Special" ships cannot be forgotten, and if they land on a planet, they
 	// continue to exist and refuel instead of being deleted.
 	bool isSpecial = false;


### PR DESCRIPTION
**Feature:** This PR ports the feature to only deploy selected fighters instead of all fighters at once.

## Feature Details
This is a port from https://github.com/endless-sky/endless-sky/pull/4719
See the original for details.

## UI Screenshots
See https://github.com/endless-sky/endless-sky/pull/4719 for a screenshot.

## Usage Examples
Select some fighters in your fleet and press deploy (and notice that only the selected fighters get deployed).
Or just press deploy with nothing selected (and notice that all fighters get deployed).
