### PR TITLE
Add the auto-test framework for ES to ES-Stories

### DIFF
--- a/EndlessSky.cbp
+++ b/EndlessSky.cbp
@@ -334,6 +334,10 @@
 		<Unit filename="source/System.h" />
 		<Unit filename="source/Table.cpp" />
 		<Unit filename="source/Table.h" />
+		<Unit filename="source/Test.cpp" />
+		<Unit filename="source/Test.h" />
+		<Unit filename="source/TestData.cpp" />
+		<Unit filename="source/TestData.h" />
 		<Unit filename="source/Trade.cpp" />
 		<Unit filename="source/Trade.h" />
 		<Unit filename="source/TradingPanel.cpp" />

--- a/EndlessSky.xcodeproj/project.pbxproj
+++ b/EndlessSky.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		6A5716331E25BE6F00585EB2 /* CollisionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6A5716311E25BE6F00585EB2 /* CollisionSet.cpp */; };
 		938E07E4235970CE00DC2C2B /* FormationPattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 938E07E0235970CE00DC2C2B /* FormationPattern.cpp */; };
 		938E07E5235970CE00DC2C2B /* FormationPositioner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 938E07E2235970CE00DC2C2B /* FormationPositioner.cpp */; };
+		9E1F4BF78F9E1FC4C96F76B5 /* Test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2E8047A8987DD8EC99FF8E2E /* Test.cpp */; };
 		A90633FF1EE602FD000DA6C0 /* LogbookPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A90633FD1EE602FD000DA6C0 /* LogbookPanel.cpp */; };
 		A90C15D91D5BD55700708F3A /* Minable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A90C15D71D5BD55700708F3A /* Minable.cpp */; };
 		A90C15DC1D5BD56800708F3A /* Rectangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A90C15DA1D5BD56800708F3A /* Rectangle.cpp */; };
@@ -163,6 +164,7 @@
 		B55C239D2303CE8B005C1A14 /* GameWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B55C239B2303CE8A005C1A14 /* GameWindow.cpp */; };
 		B5DDA6942001B7F600DBA76A /* News.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5DDA6922001B7F600DBA76A /* News.cpp */; };
 		C9779AE623922EB5009310A2 /* Crew.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9779AE423922EB5009310A2 /* Crew.cpp */; };
+		C7354A3E9C53D6C5E3CC352F /* TestData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02D34A71AE3BC4C93FC6865B /* TestData.cpp */; };
 		DF8D57E11FC25842001525DA /* Dictionary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57DF1FC25842001525DA /* Dictionary.cpp */; };
 		DF8D57E51FC25889001525DA /* Visual.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8D57E21FC25889001525DA /* Visual.cpp */; };
 		DFAAE2A61FD4A25C0072C0A8 /* BatchDrawList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAAE2A21FD4A25C0072C0A8 /* BatchDrawList.cpp */; };
@@ -193,9 +195,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02D34A71AE3BC4C93FC6865B /* TestData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestData.cpp; path = source/TestData.cpp; sourceTree = "<group>"; };
+		2E8047A8987DD8EC99FF8E2E /* Test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Test.cpp; path = source/Test.cpp; sourceTree = "<group>"; };
 		4C2DEF55201B8FAD0062315E /* libSDL2-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2-2.0.0.dylib"; path = "/usr/local/lib/libSDL2-2.0.0.dylib"; sourceTree = "<absolute>"; };
 		5155CD711DBB9FF900EF090B /* Depreciation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Depreciation.cpp; path = source/Depreciation.cpp; sourceTree = "<group>"; };
 		5155CD721DBB9FF900EF090B /* Depreciation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Depreciation.h; path = source/Depreciation.h; sourceTree = "<group>"; };
+		5CE3475B85CE8C48D98664B7 /* Test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Test.h; path = source/Test.h; sourceTree = "<group>"; };
 		6245F8231D301C7400A7A094 /* Body.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Body.cpp; path = source/Body.cpp; sourceTree = "<group>"; };
 		6245F8241D301C7400A7A094 /* Body.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Body.h; path = source/Body.h; sourceTree = "<group>"; };
 		6245F8261D301C9000A7A094 /* Hardpoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Hardpoint.cpp; path = source/Hardpoint.cpp; sourceTree = "<group>"; };
@@ -208,6 +213,7 @@
 		62C311191CE172D000409D91 /* Flotsam.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Flotsam.h; path = source/Flotsam.h; sourceTree = "<group>"; };
 		6A5716311E25BE6F00585EB2 /* CollisionSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CollisionSet.cpp; path = source/CollisionSet.cpp; sourceTree = "<group>"; };
 		6A5716321E25BE6F00585EB2 /* CollisionSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollisionSet.h; path = source/CollisionSet.h; sourceTree = "<group>"; };
+		9DA14712A9C68E00FBFD9C72 /* TestData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestData.h; path = source/TestData.h; sourceTree = "<group>"; };
 		938E07E0235970CE00DC2C2B /* FormationPattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FormationPattern.cpp; path = source/FormationPattern.cpp; sourceTree = "<group>"; };
 		938E07E1235970CE00DC2C2B /* FormationPattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FormationPattern.h; path = source/FormationPattern.h; sourceTree = "<group>"; };
 		938E07E2235970CE00DC2C2B /* FormationPositioner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FormationPositioner.cpp; path = source/FormationPositioner.cpp; sourceTree = "<group>"; };
@@ -778,6 +784,10 @@
 				A968639D1AE6FD0D004FE1FE /* Weapon.h */,
 				A968639E1AE6FD0D004FE1FE /* WrappedText.cpp */,
 				A968639F1AE6FD0E004FE1FE /* WrappedText.h */,
+				2E8047A8987DD8EC99FF8E2E /* Test.cpp */,
+				02D34A71AE3BC4C93FC6865B /* TestData.cpp */,
+				9DA14712A9C68E00FBFD9C72 /* TestData.h */,
+				5CE3475B85CE8C48D98664B7 /* Test.h */,
 			);
 			name = source;
 			sourceTree = "<group>";
@@ -1054,6 +1064,8 @@
 				A96863CE1AE6FD0E004FE1FE /* LoadPanel.cpp in Sources */,
 				A96863A41AE6FD0E004FE1FE /* Armament.cpp in Sources */,
 				A96863F01AE6FD0E004FE1FE /* Screen.cpp in Sources */,
+				9E1F4BF78F9E1FC4C96F76B5 /* Test.cpp in Sources */,
+				C7354A3E9C53D6C5E3CC352F /* TestData.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/data/tests/tests_cargo.txt
+++ b/data/tests/tests_cargo.txt
@@ -1,0 +1,290 @@
+# Copyright 2020 by Peter van der Meer
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+test-data "commodity barges"
+	category "savegame"
+	contents
+		pilot Bobbi Bughunter
+		date 16 11 3013
+		system Sol
+		planet Earth
+		clearance
+		# Set some reputations to positive to avoid combat
+		"reputation with"
+			Bounty 1
+			"Bounty Hunter" 1
+			Pirate 1
+		# What you own:
+		ship "Star Barge"
+			name "Buggy Barge"
+			sprite "ship/star barge"
+			attributes
+				category "Light Freighter"
+				cost 190000
+				mass 70
+				bunks 3
+				"cargo space" 50
+				drag 2.1
+				"engine capacity" 40
+				"fuel capacity" 300
+				"heat dissipation" 0.8
+				hull 1000
+				"outfit space" 130
+				"required crew" 1
+				shields 600
+				"turret mounts" 1
+				"weapon capacity" 20
+			outfits
+				"X1700 Ion Thruster"
+				"X1200 Ion Steering"
+				Hyperdrive
+				"Anti-Missile Turret"
+				"D14-RN Shield Generator"
+				"nGVF-BB Fuel Cell"
+				"LP036a Battery Pack"
+			crew 1
+			fuel 300
+			shields 600
+			hull 1000
+			position 0 0
+			engine -9 38 1
+			engine 9 38 1
+			turret 0 -8 "Anti-Missile Turret"
+			leak leak 60 50
+			explode "tiny explosion" 10
+			explode "small explosion" 10
+			system Sol
+			planet Earth
+		ship "Star Barge"
+			name "Critical Container"
+			sprite "ship/star barge"
+			attributes
+				category "Light Freighter"
+				cost 190000
+				mass 70
+				bunks 3
+				"cargo space" 50
+				drag 2.1
+				"engine capacity" 40
+				"fuel capacity" 300
+				"heat dissipation" 0.8
+				hull 1000
+				"outfit space" 130
+				"required crew" 1
+				shields 600
+				"turret mounts" 1
+				"weapon capacity" 20
+			outfits
+				"X1700 Ion Thruster"
+				"X1200 Ion Steering"
+				Hyperdrive
+				"Anti-Missile Turret"
+				"D14-RN Shield Generator"
+				"nGVF-BB Fuel Cell"
+				"LP036a Battery Pack"
+			crew 1
+			fuel 300
+			shields 600
+			hull 1000
+			position 0 0
+			engine -9 38 1
+			engine 9 38 1
+			turret 0 -8 "Anti-Missile Turret"
+			leak leak 60 50
+			explode "tiny explosion" 10
+			explode "small explosion" 10
+			system Sol
+			planet Earth
+		ship "Star Barge"
+			name "Errorous Enclosement"
+			sprite "ship/star barge"
+			attributes
+				category "Light Freighter"
+				cost 190000
+				mass 70
+				bunks 3
+				"cargo space" 50
+				drag 2.1
+				"engine capacity" 40
+				"fuel capacity" 300
+				"heat dissipation" 0.8
+				hull 1000
+				"outfit space" 130
+				"required crew" 1
+				shields 600
+				"turret mounts" 1
+				"weapon capacity" 20
+			outfits
+				"X1700 Ion Thruster"
+				"X1200 Ion Steering"
+				Hyperdrive
+				"Anti-Missile Turret"
+				"D14-RN Shield Generator"
+				"nGVF-BB Fuel Cell"
+				"LP036a Battery Pack"
+			crew 1
+			fuel 300
+			shields 600
+			hull 1000
+			position 0 0
+			engine -9 38 1
+			engine 9 38 1
+			turret 0 -8 "Anti-Missile Turret"
+			leak leak 60 50
+			explode "tiny explosion" 10
+			explode "small explosion" 10
+			system Sol
+			planet Earth
+		account
+			credits 131000
+			score 400
+			history
+		cargo
+			commodities
+				Food 150
+		visited Sol
+		"visited planet" Earth
+		visited "Alpha Centauri"
+		visited "Vega"
+		visited "Menkent"
+
+
+
+test-data "outfits cargo overload"
+	category "savegame"
+	contents
+		pilot Bobbi Bughunter
+		date 16 11 3013
+		system Sol
+		planet Earth
+		clearance
+		# Set some reputations to positive to avoid combat
+		"reputation with"
+			Bounty 1
+			"Bounty Hunter" 1
+			Pirate 1
+		ship "Star Barge"
+			name "Buggy Barge"
+			sprite "ship/star barge"
+			attributes
+				category "Light Freighter"
+				cost 190000
+				mass 70
+				bunks 3
+				"cargo space" 50
+				drag 2.1
+				"engine capacity" 40
+				"fuel capacity" 300
+				"heat dissipation" 0.8
+				hull 1000
+				"outfit space" 130
+				"required crew" 1
+				shields 600
+				"turret mounts" 1
+				"weapon capacity" 20
+			outfits
+				"X1700 Ion Thruster"
+				"X1200 Ion Steering"
+				Hyperdrive
+				"Anti-Missile Turret"
+				"D14-RN Shield Generator"
+				"nGVF-BB Fuel Cell"
+				"LP036a Battery Pack"
+			crew 1
+			fuel 300
+			shields 600
+			hull 1000
+			position 0 0
+			engine -9 38 1
+			engine 9 38 1
+			turret 0 -8 "Anti-Missile Turret"
+			leak leak 60 50
+			explode "tiny explosion" 10
+			explode "small explosion" 10
+			system Sol
+			planet Earth
+		ship "Star Barge"
+			name "Critical Container"
+			sprite "ship/star barge"
+			attributes
+				category "Light Freighter"
+				cost 190000
+				mass 70
+				bunks 3
+				"cargo space" 50
+				drag 2.1
+				"engine capacity" 40
+				"fuel capacity" 300
+				"heat dissipation" 0.8
+				hull 1000
+				"outfit space" 130
+				"required crew" 1
+				shields 600
+				"turret mounts" 1
+				"weapon capacity" 20
+			outfits
+				"X1700 Ion Thruster"
+				"X1200 Ion Steering"
+				Hyperdrive
+				"Anti-Missile Turret"
+				"D14-RN Shield Generator"
+				"nGVF-BB Fuel Cell"
+				"LP036a Battery Pack"
+			crew 1
+			fuel 300
+			shields 600
+			hull 1000
+			position 0 0
+			engine -9 38 1
+			engine 9 38 1
+			turret 0 -8 "Anti-Missile Turret"
+			leak leak 60 50
+			explode "tiny explosion" 10
+			explode "small explosion" 10
+			system Sol
+			planet Earth
+		account
+			credits 131000
+			score 400
+			history
+		cargo
+			outfits
+				"Boulder Reactor" 1
+		visited Sol
+		"visited planet" Earth
+
+
+
+test "Cargo Commodoties Transport"
+	status "Missing Feature"
+	sequence
+		inject "commodity barges"
+		load "commodity barges.txt"
+		assert
+			"cargo space" == 0
+		launch
+		land
+		assert
+			"cargo space" == 0
+
+
+
+test "Cargo oversized outfit"
+	status "Known Failure"
+	bug-id "None yet"
+	sequence
+		inject "outfits cargo overload"
+		load "outfits cargo overload.txt"
+		assert
+			"cargo space" == 10
+		launch
+		land
+		assert
+			"cargo space" == 10

--- a/data/tests/tests_framework.txt
+++ b/data/tests/tests_framework.txt
@@ -1,0 +1,120 @@
+# Copyright 2020 by Peter van der Meer
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+test "Test-Framework - Empty Testcase"
+	status "Active"
+	description "Test with an empty sequence. Only starts and exits the game"
+
+
+
+test "Test-Framework - Load only"
+	status "Active"
+	description "Tests only loading of a game and then exits the game"
+	sequence
+		inject "commodity barges"
+		load "commodity barges.txt"
+		assert
+			"ships: Light Freighter" = 3
+
+
+
+test "Test-Framework - Load and depart"
+	status "Active"
+	description "Test with only a departure. Mostly tests the testframework itself."
+	sequence
+		inject "commodity barges"
+		load "commodity barges.txt"
+		assert
+			"ships: Light Freighter" = 3
+		launch
+		assert
+			"ships: Light Freighter" = 3
+
+
+
+test "Test-Framework - Simple depart land"
+	status "Active"
+	description "Test with only a departure and landing. Mostly tests the testframework itself."
+	sequence
+		inject "commodity barges"
+		load "commodity barges.txt"
+		launch
+		land
+
+
+
+test "Test-Framework - Depart and commanded landing"
+	status "Active"
+	description "Test with depart and land, uses command and conditions for executing the landing."
+	sequence
+		inject "commodity barges"
+		load "commodity barges.txt"
+		launch
+		navigate
+			travel "Menkent"
+			travel "Vega"
+		command jump
+		"wait for"
+			has "flagship system: Menkent"
+		command	land
+		"wait for"
+			has "flagship planet: New Austria"
+
+
+
+test "Test-Framework - Navigate"
+	status "Active"
+	description "Test Navigation to other star system"
+	sequence
+		inject "commodity barges"
+		load "commodity barges.txt"
+		navigate
+			travel "Alpha Centauri"
+			travel "Sol"
+			travel "Alpha Centauri"
+		launch
+		command	jump
+		"wait for"
+			has "flagship system: Alpha Centauri"
+		"wait for"
+			has "flagship system: Sol"
+		"wait for"
+			has "flagship system: Alpha Centauri"
+
+
+
+test "Test-Framework - Loops and counts"
+	status "Active"
+	description "Test Loops and condition assignments and reading"
+	sequence
+		inject "commodity barges"
+		load "commodity barges.txt"
+		launch
+		assign
+			"Test loop" = 0
+		repeat
+			"break if"
+				"Test loop" > 3
+			assign
+				"Test inner loop" = 50
+			repeat
+				"break if"
+					"Test inner loop" <= 25
+				command left
+				assign
+					"Test inner loop" --
+			repeat
+				"break if"
+					"Test inner loop" <= 0
+				command forward
+				assign
+					"Test inner loop" --
+			assign
+				"Test loop" ++

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -221,6 +221,70 @@ bool Command::HasConflict() const
 
 
 
+// Load this command from an input file (for testing or scripted missions).
+void Command::Load(const DataNode &node)
+{
+	for(int i = 1; i < node.Size(); ++i)
+	{
+		const string &input = node.Token(i);
+		
+		if(input == "menu")
+			Set(Command::MENU);
+		else if(input == "forward")
+			Set(Command::FORWARD);
+		else if(input == "left")
+			Set(Command::LEFT);
+		else if(input == "right")
+			Set(Command::RIGHT);
+		else if(input == "back")
+			Set(Command::BACK);
+		else if(input == "primary")
+			Set(Command::PRIMARY);
+		else if(input == "secondary")
+			Set(Command::SECONDARY);
+		else if(input == "select")
+			Set(Command::SELECT);
+		else if(input == "land")
+			Set(Command::LAND);
+		else if(input == "board")
+			Set(Command::BOARD);
+		else if(input == "hail")
+			Set(Command::HAIL);
+		else if(input == "scan")
+			Set(Command::SCAN);
+		else if(input == "jump")
+			Set(Command::JUMP);
+		else if(input == "target")
+			Set(Command::TARGET);
+		else if(input == "nearest")
+			Set(Command::NEAREST);
+		else if(input == "deploy")
+			Set(Command::DEPLOY);
+		else if(input == "afterburner")
+			Set(Command::AFTERBURNER);
+		else if(input == "cloak")
+			Set(Command::CLOAK);
+		else if(input == "map")
+			Set(Command::MAP);
+		else if(input == "info")
+			Set(Command::INFO);
+		else if(input == "fight")
+			Set(Command::FIGHT);
+		else if(input == "gather")
+			Set(Command::GATHER);
+		else if(input == "hold")
+			Set(Command::HOLD);
+		else if(input == "ammo")
+			Set(Command::AMMO);
+		else
+			node.PrintTrace("Skipping unrecognized command:");
+
+		++i;
+	}
+}
+
+
+
 // Reset this to an empty command.
 void Command::Clear()
 {

--- a/source/Command.h
+++ b/source/Command.h
@@ -16,6 +16,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <cstdint>
 #include <string>
 
+class DataNode;
+
 
 
 // Class mapping key presses to specific commands / actions. The player can
@@ -95,6 +97,9 @@ public:
 	const std::string &Description() const;
 	const std::string &KeyName() const;
 	bool HasConflict() const;
+	
+	// Load this command from an input file (for testing or scripted missions).
+	void Load(const DataNode &node);
 	
 	// Reset this to an empty command.
 	void Clear();

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1039,6 +1039,14 @@ void Engine::Draw() const
 
 
 
+// Give an (automated/scripted) command on behalf of the player.
+void Engine::GiveCommand(const Command &command)
+{
+	activeCommands.Set(command);
+}
+
+
+
 // Select the object the player clicked on.
 void Engine::Click(const Point &from, const Point &to, bool hasShift)
 {

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -79,6 +79,8 @@ public:
 	// Draw a frame.
 	void Draw() const;
 	
+	// Give an (automated/scripted) command on behalf of the player.
+	void GiveCommand(const Command &command);
 	// Select the object the player clicked on.
 	void Click(const Point &from, const Point &to, bool hasShift);
 	void RClick(const Point &point);

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -40,6 +40,7 @@ namespace {
 	string images;
 	string sounds;
 	string saves;
+	string tests;
 	
 	mutex errorMutex;
 	File errorLog;
@@ -224,6 +225,13 @@ const string &Files::Sounds()
 const string &Files::Saves()
 {
 	return saves;
+}
+
+
+
+const string &Files::Tests()
+{
+	return tests;
 }
 
 

--- a/source/Files.h
+++ b/source/Files.h
@@ -37,6 +37,7 @@ public:
 	static const std::string &Images();
 	static const std::string &Sounds();
 	static const std::string &Saves();
+	static const std::string &Tests();
 	
 	// Get a list of all regular files in the given directory.
 	static std::vector<std::string> List(std::string directory);

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -55,6 +55,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "StarField.h"
 #include "StartConditions.h"
 #include "System.h"
+#include "Test.h"
+#include "TestData.h"
 
 #include <algorithm>
 #include <iostream>
@@ -85,6 +87,8 @@ namespace {
 	Set<Planet> planets;
 	Set<Ship> ships;
 	Set<System> systems;
+	Set<Test> tests;
+	Set<TestData> testDataSets;
 	
 	Set<Sale<Ship>> shipSales;
 	Set<Sale<Outfit>> outfitSales;
@@ -129,6 +133,7 @@ namespace {
 bool GameData::BeginLoad(const char * const *argv)
 {
 	bool printShips = false;
+	bool printTests = false;
 	bool printWeapons = false;
 	bool debugMode = false;
 	for(const char * const *it = argv + 1; *it; ++it)
@@ -140,6 +145,8 @@ bool GameData::BeginLoad(const char * const *argv)
 				printShips = true;
 			if(arg == "-w" || arg == "--weapons")
 				printWeapons = true;
+			if(arg == "--tests")
+				printTests = true;
 			if(arg == "-d" || arg == "--debug")
 				debugMode = true;
 			continue;
@@ -211,9 +218,11 @@ bool GameData::BeginLoad(const char * const *argv)
 	
 	if(printShips)
 		PrintShipTable();
+	if(printTests)
+		PrintTestsTable();
 	if(printWeapons)
 		PrintWeaponTable();
-	return !(printShips || printWeapons);
+	return !(printShips || printWeapons || printTests);
 }
 
 
@@ -711,6 +720,20 @@ const Set<Ship> &GameData::Ships()
 
 
 
+const Set<Test> &GameData::Tests()
+{
+	return tests;
+}
+
+
+
+const Set<TestData> &GameData::TestDataSets()
+{
+	return testDataSets;
+}
+
+
+
 const Set<Sale<Ship>> &GameData::Shipyards()
 {
 	return shipSales;
@@ -984,6 +1007,10 @@ void GameData::LoadFile(const string &path, bool debugMode)
 			startConditions.Load(node);
 		else if(key == "system" && node.Size() >= 2)
 			systems.Get(node.Token(1))->Load(node, planets);
+		else if((key == "test") && node.Size() >= 2)
+			tests.Get(node.Token(1))->Load(node);
+		else if((key == "test-data") && node.Size() >= 2)
+			testDataSets.Get(node.Token(1))->Load(node, path);
 		else if(key == "trade")
 			trade.Load(node);
 		else if(key == "landing message" && node.Size() >= 2)
@@ -1058,6 +1085,22 @@ map<string, shared_ptr<ImageSet>> GameData::FindImages()
 			}
 	}
 	return images;
+}
+
+
+
+// This prints out the list of tests that are available and their status
+// (active/missing feature/known failure)..
+void GameData::PrintTestsTable()
+{
+	cout << "name" << '\t' << "status" << '\n';
+	for(auto &it : tests)
+	{
+		const Test &test = it.second;
+		cout << test.Name() << '\t';
+		cout << test.StatusText() << '\n';
+	}
+	cout.flush();
 }
 
 

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -49,6 +49,8 @@ class Sprite;
 class StarField;
 class StartConditions;
 class System;
+class Test;
+class TestData;
 
 
 
@@ -113,6 +115,8 @@ public:
 	static const Set<Ship> &Ships();
 	static const Set<Sale<Ship>> &Shipyards();
 	static const Set<System> &Systems();
+	static const Set<Test> &Tests();
+	static const Set<TestData> &TestDataSets();
 	
 	static const Government *PlayerGovernment();
 	static Politics &GetPolitics();
@@ -151,6 +155,7 @@ private:
 	static std::map<std::string, std::shared_ptr<ImageSet>> FindImages();
 	
 	static void PrintShipTable();
+	static void PrintTestsTable();
 	static void PrintWeaponTable();
 };
 

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -342,7 +342,7 @@ bool GameWindow::HasSwizzle()
 
 
 
-void GameWindow::ExitWithError(const string& message)
+void GameWindow::ExitWithError(const string& message, bool doPopUp)
 {
 	// Print the error message in the terminal and the error file.
 	Files::LogError(message);		
@@ -364,7 +364,8 @@ void GameWindow::ExitWithError(const string& message)
 	box.buttons = &button;
 	
 	int result = 0;
-	SDL_ShowMessageBox(&box, &result);
+	if(doPopUp)
+		SDL_ShowMessageBox(&box, &result);
 	
 	GameWindow::Quit();	
 }

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -44,7 +44,7 @@ public:
 	
 	// Print the error message in the terminal, error file, and message box.
 	// Checks for video system errors and records those as well.
-	static void ExitWithError(const std::string& message);
+	static void ExitWithError(const std::string& message, bool doPopUp = true);
 };
 
 

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -219,6 +219,14 @@ bool MainPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 
 
 
+// Send a command through the main-panel to the engine
+void MainPanel::GiveCommand(const Command &command)
+{
+	engine.GiveCommand(command);
+}
+
+
+
 bool MainPanel::Click(int x, int y, int clicks)
 {
 	// Don't respond to clicks if another panel is active.

--- a/source/MainPanel.h
+++ b/source/MainPanel.h
@@ -39,6 +39,8 @@ public:
 	// The planet panel calls this when it closes.
 	void OnCallback();
 	
+	void GiveCommand(const Command &command);
+	
 	
 protected:
 	// Only override the ones you need; the default action is to return false.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1902,7 +1902,7 @@ const Planet *PlayerInfo::TravelDestination() const
 void PlayerInfo::SetTravelDestination(const Planet *planet)
 {
 	travelDestination = planet;
-	if(planet->IsInSystem(system) && Flagship())
+	if(planet && planet->IsInSystem(system) && Flagship())
 		Flagship()->SetTargetStellar(system->FindStellar(planet));
 }
 

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -1,0 +1,527 @@
+/* Test.cpp
+Copyright (c) 2019 by Peter van der Meer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "Test.h"
+
+#include "DataNode.h"
+#include "Files.h"
+#include "GameData.h"
+#include "MainPanel.h"
+#include "Panel.h"
+#include "Planet.h"
+#include "PlanetPanel.h"
+#include "PlayerInfo.h"
+#include "Ship.h"
+#include "System.h"
+#include "TestData.h"
+#include "UI.h"
+
+#include <SDL2/SDL.h>
+
+#include <stdexcept>
+
+using namespace std;
+
+namespace {
+	bool SendFlightCommand(const Command &command, UI &gamePanels)
+	{
+		// We need to send the command to the top gamepanel. And it needs to be active.
+		if(gamePanels.IsEmpty() || gamePanels.Root() != gamePanels.Top())
+			return false;
+		
+		// Both get as well as the cast can result in a nullpointer. In both cases we
+		// return false.
+		MainPanel* mainPanel = dynamic_cast<MainPanel*> (gamePanels.Root().get());
+		if(!mainPanel)
+			return false;
+		
+		mainPanel->GiveCommand(command);
+		return true;
+	}
+	
+	bool PlayerIsFlyingAround(UI &menuPanels, UI &gamePanels, PlayerInfo &player)
+	{
+		// Code borrowed from main.cpp
+		bool inFlight = (menuPanels.IsEmpty() && gamePanels.Root() == gamePanels.Top());
+		return inFlight;
+	}
+
+	bool PlayerMenuIsActive(UI &menuPanels)
+	{
+		return !menuPanels.IsEmpty();
+	}
+
+	PlanetPanel* GetPlanetPanelIfAvailable(UI &gamePanels)
+	{
+		if(gamePanels.IsEmpty()){
+			return nullptr;
+		}
+		Panel *topPanel = gamePanels.Top().get();
+		// If we can cast the topPanel from the gamePanels to planetpanel,
+		// then we have landed and are on a planet.
+		return dynamic_cast<PlanetPanel*>(topPanel);
+	}
+
+	bool PlayerOnPlanetMainScreen(UI &menuPanels, UI &gamePanels, PlayerInfo &player)
+	{
+		if(!menuPanels.IsEmpty())
+			return false;
+		if(gamePanels.Root() == gamePanels.Top())
+			return false;
+
+		PlanetPanel *topPlanetPanel = GetPlanetPanelIfAvailable(gamePanels);
+		return topPlanetPanel != nullptr;
+	}
+	
+	// Send an SDL_event to on of the UIs.
+	bool EventToUI(UI &menuOrGamePanels, const SDL_Event &event)
+	{
+		return menuOrGamePanels.Handle(event);
+	}
+	
+	// Send an keyboard input to one of the UIs.
+	bool KeyInputToUI(UI &menuOrGamePanels, const char* keyName, bool shift=false, bool ctrl=false, bool alt=false)
+	{
+		// Construct the event to send (from keyboard code and modifiers)
+		SDL_Event event;
+		event.key.keysym.sym = SDL_GetKeyFromName(keyName);
+		event.key.keysym.mod = KMOD_NONE;
+		if(shift)
+			event.key.keysym.mod |= KMOD_SHIFT;
+		if(ctrl)
+			event.key.keysym.mod |= KMOD_CTRL;
+		if(alt)
+			event.key.keysym.mod |= KMOD_ALT;
+		
+		return EventToUI(menuOrGamePanels, event);
+	}
+
+	// Retrieve a set of teststeps based on the stepToRun from context. This is usually directly from the test-sequence, but
+	// can be from an inner loop when a REPEAT-loop or other loop is used.
+	const vector<Test::TestStep> GetTestSteps(const vector<unsigned int> stepToRun, const vector<Test::TestStep> topLevel)
+	{
+		if(stepToRun.empty())
+			return vector<Test::TestStep>();
+		if(stepToRun.size()==1)
+			return topLevel;
+		// Construct temporary array for accessing one level lower.
+		vector<unsigned int> tmpSteps(stepToRun.begin() + 1, stepToRun.end());
+		// Perform recursive call to get the vector from one level lower.
+		return GetTestSteps(tmpSteps, topLevel[stepToRun[0]].SubSteps());
+	}
+}
+
+
+
+void Test::Load(const DataNode &node)
+{
+	if(node.Size() < 2)
+	{
+		node.PrintTrace("No name specified for test");
+		return;
+	}
+	// If a test object is "loaded" twice, that is most likely an error (e.g.
+	// due to a plugin containing a test with the same name as the base game
+	// or another plugin). Tests should be globally unique.
+	if(!name.empty())
+	{
+		node.PrintTrace("Duplicate definition of test");
+		return;
+	}
+	name = node.Token(1);
+
+	for(const DataNode &child : node)
+	{
+		if(child.Token(0) == "status" && child.Size() >= 2)
+		{
+			if(child.Token(1) == "Active")
+				status = STATUS_ACTIVE;
+			else if(child.Token(1) == "Known Failure")
+				status = STATUS_KNOWN_FAILURE;
+			else if(child.Token(1) == "Missing Feature")
+				status = STATUS_MISSING_FEATURE;
+		}
+		else if(child.Token(0) == "sequence")
+			for(const DataNode &seqChild : child)
+				testSteps.emplace_back(TestStep(seqChild));
+	}
+}
+
+
+
+const string &Test::Name() const
+{
+	return name;
+}
+
+
+
+string Test::DebugMessage(Context &context) const
+{
+	// Generate a message that tells which part of the test is running
+	string testStatus = "";
+	for(unsigned int i = 0; i < context.stepToRun.size(); ++i)
+		testStatus += "stack: " + to_string(i) + ", step: " + to_string(context.stepToRun[i]) + "; ";
+	return testStatus;
+}
+
+
+
+// The panel-stacks determine both what the player sees and the state of the
+// game.
+// If the menuPanels stack is not empty, then we are in a menu for something
+// like preferences, creating a new pilot or loading or saving a game.
+// The menuPanels stack takes precedence over the gamePanels stack.
+// If the gamePanels stack contains more than one panel, then we are either
+// on a planet (if the PlanetPanel is in the stack) or we are busy with
+// something like a mission-dialog, hailing or boarding.
+// If the gamePanels stack contains only a single panel, then we are flying
+// around in our flagship.
+void Test::Step(Context &context, UI &menuPanels, UI &gamePanels, PlayerInfo &player) const
+{
+	// Wait with testing until the game is fully loaded.
+	if(GameData::Progress() < 1.)
+		return;
+	
+	if(context.stepToRun.empty() || context.stepToRun[0] >= testSteps.size())
+	{
+		// Done, no failures, exit the game with exitcode success.
+		menuPanels.Quit();
+		return;
+	}
+	
+	// Get the container of the inner loop and the currently running teststep within the loop.
+	// Needed to use a helper function to ensure const qualifiers remained working.
+	const vector<TestStep> &testStepsContainer = GetTestSteps(context.stepToRun, testSteps);
+	const TestStep &testStep = testStepsContainer[context.stepToRun[context.stepToRun.size() - 1]];
+
+	Test::TestStep::TestResult testResult = testStep.Step(context.stepAction, menuPanels, gamePanels, player);
+	switch(testResult)
+	{
+		case TestStep::RESULT_DONE:
+			// Test-step is done. Start with the first action of the next
+			// step next time this function gets called.
+			++context.stepToRun[context.stepToRun.size()-1];
+			context.stepAction = 0;
+			break;
+		case TestStep::RESULT_NEXTACTION:
+			++context.stepAction;
+			break;
+		case TestStep::RESULT_RETRY:
+			break;
+		case TestStep::RESULT_BREAK:
+			// First pop-off the top-level item
+			if(context.stepToRun.size() > 0)
+				context.stepToRun.pop_back();
+			// Then advance the command above it
+			if(context.stepToRun.size() > 0)
+				++context.stepToRun[context.stepToRun.size()-1];
+			context.stepAction = 0;
+			break;
+		case TestStep::RESULT_LOOP:
+			context.stepToRun.push_back(0);
+			break;
+		case TestStep::RESULT_FAIL:
+		default:
+			// Exit with error on a failing testStep.
+			// Throwing a runtime_error is kinda rude, but works for this version of
+			// the tester. Might want to add a menuPanels.QuitError() function in
+			// a later version (which can set a non-zero exitcode and exit properly).
+			throw runtime_error("Teststep " + DebugMessage(context) + " failed");
+	}
+	
+	// Special case: if we are in a loop, then stepping beyond the last entry should return us to the first.
+	if(context.stepToRun.size() > 1 && context.stepToRun[context.stepToRun.size()-1] >= GetTestSteps(context.stepToRun, testSteps).size())
+		context.stepToRun[context.stepToRun.size()-1] = 0;
+}
+
+
+
+const vector<Test::TestStep> Test::TestStep::SubSteps() const
+{
+	return testSteps;
+}
+
+
+
+string Test::StatusText() const
+{
+	switch (status)
+	{
+		case Test::STATUS_KNOWN_FAILURE:
+			return "KNOWN FAILURE";
+		case Test::STATUS_MISSING_FEATURE:
+			return "MISSING FEATURE";
+		case Test::STATUS_ACTIVE:
+		default:
+			return "ACTIVE";
+	}
+}
+
+
+
+Test::TestStep::TestStep(const DataNode &node)
+{
+	Load(node);
+}
+
+
+
+void Test::TestStep::Load(const DataNode &node)
+{
+	if(node.Token(0) == "assign")
+	{
+		stepType = ASSIGN;
+		checkedCondition.Load(node);
+	}
+	else if(node.Token(0) == "assert")
+	{
+		stepType = ASSERT;
+		checkedCondition.Load(node);
+	}
+	else if(node.Token(0) == "break if")
+	{
+		stepType = BREAK_IF;
+		checkedCondition.Load(node);
+	}
+	else if(node.Token(0) == "command")
+	{
+		stepType = COMMAND;
+		command.Load(node);
+	}
+	else if(node.Token(0) == "land")
+		stepType = LAND;
+	else if(node.Token(0) == "launch")
+		stepType = LAUNCH;
+	else if(node.Token(0) == "repeat")
+	{
+		stepType = REPEAT;
+		for(const DataNode &seqChild : node)
+			testSteps.emplace_back(TestStep(seqChild));
+	}
+	else if(node.Token(0) == "navigate")
+	{
+		stepType = NAVIGATE;
+		for(const DataNode &child : node)
+		{
+			if(child.Token(0) == "travel" && child.Size() >= 2)
+			{
+				// Using get instead of find since the test might be loaded
+				// before the actual system is loaded.
+				const System *next = GameData::Systems().Get(child.Token(1));
+				if(next)
+					travelPlan.push_back(next);
+			}
+			// Using get instead of find since the test might be loaded before
+			// the actual planet is loaded.
+			else if(child.Token(0) == "travel destination" && child.Size() >= 2)
+				travelDestination = GameData::Planets().Get(child.Token(1));
+		}
+	}
+	else if(node.Token(0) == "wait for")
+	{
+		stepType = WAITFOR;
+		checkedCondition.Load(node);
+	}
+	else if(node.Size() < 2)
+		node.PrintTrace("Skipping unrecognized or incomplete test-step: " + node.Token(0));
+	else if(node.Token(0) == "command")
+	{
+		stepType = COMMAND;
+		command.Load(node);
+	}
+	else if(node.Token(0) == "load")
+	{
+		stepType = LOAD_GAME;
+		stepInputString = node.Token(1);
+	}
+	else if(node.Token(0) == "inject")
+	{
+		stepType = INJECT;
+		stepInputString = node.Token(1);
+	}
+	else if(node.Token(0) == "ui key")
+	{
+		stepType = UI_KEY;
+		stepInputString = node.Token(1);
+	}
+	else
+		node.PrintTrace("Skipping unrecognized test-step: " + node.Token(0));
+}
+
+
+
+Test::TestStep::TestResult Test::TestStep::Step(int stepAction, UI &menuPanels, UI &gamePanels, PlayerInfo &player) const
+{
+	switch (stepType)
+	{
+		case TestStep::ASSIGN:
+			checkedCondition.Apply(player.Conditions());
+			return RESULT_DONE;
+			
+		case TestStep::ASSERT:
+			if(checkedCondition.Test(player.Conditions()))
+				return RESULT_DONE;
+			return RESULT_FAIL;
+			
+		case TestStep::BREAK_IF:
+			if(checkedCondition.Test(player.Conditions()))
+				return RESULT_BREAK;
+			// We only break if the condition is true.
+			return RESULT_DONE;
+			
+		case TestStep::COMMAND:
+			if(!SendFlightCommand(command, gamePanels))
+				return RESULT_FAIL;
+			return RESULT_DONE;
+			
+		case TestStep::INJECT:
+			{
+				// Lookup the data and inject it in the game or the games environment
+				const TestData* testData = (GameData::TestDataSets()).Get(stepInputString);
+				if(testData->Inject())
+					return RESULT_DONE;
+				return RESULT_FAIL;
+			}
+			
+		case TestStep::LAND:
+			// If the player/game menu is active, then we are not in a state
+			// where land makes sense.
+			if(PlayerMenuIsActive(menuPanels))
+				return RESULT_FAIL;
+			// If we are still flying around, then we are not on a planet.
+			if(PlayerIsFlyingAround(menuPanels, gamePanels, player))
+			{
+				Ship * playerFlagShip = player.Flagship();
+				if(!playerFlagShip)
+					return RESULT_FAIL;
+				if(stepAction == 0)
+				{
+					// Send the land command here
+					// Player commands are handled in Engine.cpp (at the moment this code was updated)
+					// TODO: Landing should also have a stellar target (just to reduce ambiguity)
+					Command command;
+					command.Set(Command::LAND);
+					if(!SendFlightCommand(command, gamePanels))
+						return RESULT_FAIL;
+				}
+				return RESULT_NEXTACTION;
+			}
+			if(PlayerOnPlanetMainScreen(menuPanels, gamePanels, player))
+				return RESULT_DONE;
+
+			// Unknown state/screen. Landing fails.
+			return RESULT_FAIL;
+			
+		case TestStep::LAUNCH:
+			// If we have no flagship, then we cannot launch
+			if(!player.Flagship())
+				return RESULT_FAIL;
+			// Should implement some function to close this menu. But
+			// fail for now if the player/game menu is active.
+			if(PlayerMenuIsActive(menuPanels))
+				return RESULT_FAIL;
+			if(PlayerOnPlanetMainScreen(menuPanels, gamePanels, player)){
+				// Launch using the conversation mechanism. Not the most
+				// appropriate way to launch, but works for now.
+				player.BasicCallback(Conversation::LAUNCH);
+				return RESULT_RETRY;
+			}
+			// Wait for launch sequence to complete (zoom go to one)
+			// We already checked earlier if we have a flagship
+			if(player.Flagship()->Zoom() < 1.)
+				return RESULT_RETRY;
+			// If flying around, then launching the ship succesfully happened
+			if(PlayerIsFlyingAround(menuPanels, gamePanels, player))
+				return RESULT_DONE;
+			// No idea where we are and what we are doing. But we are not
+			// in a position to launch, so fail this teststep.
+			return RESULT_FAIL;
+			
+		case TestStep::LOAD_GAME:
+			{
+				// Check if the savegame actually exists
+				if(!Files::Exists(Files::Saves() + stepInputString))
+					return RESULT_FAIL;
+				
+				// Inspired by LoadPanel.LoadCallback() to stop parallel threads.
+				// TODO: Check if we can get to a single shared function with  LoadPanel.
+				gamePanels.Reset();
+				gamePanels.CanSave(true);
+				
+				// Perform the load and verify that player is loaded.
+				player.Load(Files::Saves() + stepInputString);
+				if(!player.IsLoaded())
+					return RESULT_FAIL;
+				
+				// Remove all menus to start from freshly loaded state
+				// TODO: We should send keystrokes / commands that perform the player actions instead of modifying game structures directly.
+				int maxPops = 100;
+				while(!menuPanels.IsEmpty() && maxPops>0)
+				{
+					menuPanels.Pop(menuPanels.Top().get());
+					// Perform StepAll to execute the PushOrPop() for the
+					// actual removal of the panel.
+					menuPanels.StepAll();
+					menuPanels.StepAll();
+					maxPops--;
+				}
+				if(!menuPanels.IsEmpty())
+					return RESULT_FAIL;
+				
+				// Start from new gamePanel
+				gamePanels.Push(new MainPanel(player));
+				
+				// From LoadPanel.LoadCallback():
+				// It takes one step to figure out the planet panel should be created, and
+				// another step to actually place it. So, take two steps to avoid a flicker.
+				gamePanels.StepAll();
+				gamePanels.StepAll();
+			}
+			// Load succeeded, finish teststep.
+			return RESULT_DONE;
+			
+		case TestStep::NAVIGATE:
+			player.TravelPlan().clear();
+			player.TravelPlan() = travelPlan;
+			if(travelDestination)
+				player.SetTravelDestination(travelDestination);
+			else
+				player.SetTravelDestination(nullptr);
+			return RESULT_DONE;
+			
+		case TestStep::REPEAT:
+			return RESULT_LOOP;
+			
+		case TestStep::WAITFOR:
+			// If we reached the condition, then we are done.
+			if(checkedCondition.Test(player.Conditions()))
+				return RESULT_DONE;
+			return RESULT_RETRY;
+			
+		case TestStep::UI_KEY:
+			{
+				if(stepInputString.empty())
+					return RESULT_FAIL;
+
+				char inputChar = stepInputString[0];
+				if(KeyInputToUI(gamePanels, &inputChar))
+					return RESULT_DONE;
+				return RESULT_FAIL;
+			}
+			
+		default:
+			// ERROR, unknown test-step-type. Just return failure.
+			return RESULT_FAIL;
+			break;
+	}
+}

--- a/source/Test.h
+++ b/source/Test.h
@@ -1,0 +1,151 @@
+/* Test.h
+Copyright (c) 2019 by Peter van der Meer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef TEST_H_
+#define TEST_H_
+
+#include "Command.h"
+#include "ConditionSet.h"
+
+#include <string>
+
+class DataNode;
+class Planet;
+class PlayerInfo;
+class UI;
+class System;
+
+
+
+// Class representing a single test.
+class Test {
+public:
+	// Status indicators for the test that we selected (if any).
+	enum TestStatus {STATUS_ACTIVE, STATUS_KNOWN_FAILURE, STATUS_MISSING_FEATURE};
+	
+public:
+	// Class representing a single step in a test
+	class TestStep {
+	public:
+		// The different types of teststeps.
+		enum StepType {
+			// Step that assigns a value to a condition.
+			ASSIGN,
+			// Step that verifies if a certain condition is true
+			ASSERT,
+			// Step that breaks execution of a REPEAT loop (or stops the execution
+			// of the test itself if at toplevel) when a certain condition is
+			// true.
+			BREAK_IF,
+			// Step that performs the given command.
+			COMMAND,
+			// Step that adds game-data, either in the config-directories or in the game directly.
+			INJECT,
+			// Invalid test-step type, should not be used in tests. Used to detect issues in test-framework.
+			INVALID,
+			// Step that performs land of the players flagship.
+			LAND,
+			// Step that launches the players flagship.
+			LAUNCH,
+			// Step to perform loading of a savegame
+			LOAD_GAME,
+			// Instructs the game to set navigation / travel plan to a target system
+			NAVIGATE,
+			// Step that contains a set of test-steps below it. Repeats the
+			// steps inside it a number of times or until a break is given within
+			// the step.
+			REPEAT,
+			// Step that waits for a certain condition to become true
+			WAITFOR,
+			// Sets the watchdog timer. No value or zero disables the watchdog. Non-zero gives
+			// a watchdog in number of frames/steps.
+			WATCHDOG,
+			// Send a key-input towards a panel
+			UI_KEY,
+		};
+
+		// Result returned from a TestStep.
+		enum TestResult {
+			// Teststep succesfull. Proceed with next teststep.
+			RESULT_DONE,
+			// Teststep failed. Fail test. Exit program with non-zero exitcode
+			RESULT_FAIL,
+			// Teststep incomplete (waiting for a condition). Retry teststep in next frame-step.
+			RESULT_RETRY,
+			// Teststep incomplete (but some action was done). Retry, but with action counter one higher.
+			RESULT_NEXTACTION,
+			// Teststep indicates to break of an outer loop or break off a test (succesfully)
+			// Teststep should use RESULT_FAIL for breaking off a test with a failure.
+			RESULT_BREAK,
+			// Teststep indicated to start a loop under the current step (in case of REPEAT).
+			RESULT_LOOP
+		};
+
+		TestStep(const DataNode &node);
+
+		void Load(const DataNode &node);
+		TestResult Step(int stepAction, UI &menuPanels, UI &gamePanels, PlayerInfo &player) const;
+		
+		// Get TestSteps embedded in the current teststep (in case of loop/REPEAT type).
+		const std::vector<TestStep> SubSteps() const;
+		
+	private:
+		// The type of this step
+		StepType stepType = INVALID;
+		// Checked condition, for teststeps of types ASSERT, WAITFOR and BREAK_IF.
+		ConditionSet checkedCondition;
+		// Savegame pilot and name to load or save to, for teststeps of type LOAD_GAME (and SAVE_GAME).
+		std::string stepInputString = "";
+		// Command to send if this test-step sends a command.
+		Command command {};
+		// Set of teststeps under the current teststep, used for REPEAT type.
+		std::vector<Test::TestStep> testSteps;
+		// Variables for travelpan/NAVIGATE steps.
+		std::vector<const System *> travelPlan;
+		const Planet *travelDestination = nullptr;
+	};
+	
+	
+	class Context {
+	friend class Test;
+	
+	protected:
+		// Vector with the step to run. This array typically has only one element,
+		// but when a loop (REPEAT) is active, then it will have another element
+		// where the highest element gives the step within the loop and the lowest
+		// element gives the test-step on toplevel that has the loop.
+		std::vector<unsigned int> stepToRun = { 0 };
+		int stepAction = 0;
+	};
+	
+	
+public:
+	const std::string &Name() const;
+	std::string DebugMessage(Context &context) const;
+	std::string StatusText() const;
+
+	// PlayerInfo, the gamePanels and the MenuPanels together give the state of
+	// the game. We just provide them as parameter here, because they are not
+	// available when the test got created (and they can change due to loading
+	// and saving of games).
+	void Step(Context &context, UI &menuPanels, UI &gamePanels, PlayerInfo &player) const;
+
+	void Load(const DataNode &node);
+	
+	
+private:
+	std::vector<Test::TestStep> testSteps;
+	std::string name = "";
+	TestStatus status = STATUS_ACTIVE;
+};
+
+#endif

--- a/source/TestData.cpp
+++ b/source/TestData.cpp
@@ -1,0 +1,95 @@
+/* TestData.cpp
+Copyright (c) 2019 by Peter van der Meer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#include "TestData.h"
+
+#include "DataFile.h"
+#include "DataNode.h"
+#include "DataWriter.h"
+#include "Files.h"
+
+using namespace std;
+
+
+
+const string &TestData::Name() const
+{
+	return dataSetName;
+}
+
+
+
+// Loader to load the generic test-data entry
+void TestData::Load(const DataNode &node, const string &sourceDataFilePath)
+{
+	sourceDataFile = sourceDataFilePath;
+	if(node.Size() < 2)
+	{
+		node.PrintTrace("No name specified for test-data dataset");
+		return;
+	}
+	if(node.Token(0) != "test-data")
+	{
+		node.PrintTrace("Non-test found in test-data dataset parsing");
+		return;
+	}
+	dataSetName = node.Token(1);
+	
+	for(const DataNode &child : node)
+		// Only need to parse the category for now. The contents will be
+		// scanned for at write-out of the test-data.
+		if(child.Size() > 1 && child.Token(0) == "category" && child.Token(1) == "savegame")
+			dataSetType = TestData::SAVEGAME;
+}
+
+
+
+// Inject the test-data to the proper location
+bool TestData::Inject() const
+{
+	// We only know how to inject savegame data for now.
+	if((dataSetType != TestData::SAVEGAME) || (dataSetName.empty()) || (sourceDataFile.empty()))
+		return false;
+
+	// Open the source-file and scan until we find the test-data
+	// Then scan for the contents keyword
+	// Then write out the complete contents to the target file
+	DataFile sourceData{sourceDataFile};
+	for(const DataNode &rootNode : sourceData)
+		// Check if we have found our dataset
+		if(rootNode.Size() > 1 && rootNode.Token(0) == "test-data" && rootNode.Token(1) == dataSetName)
+		{
+			// Scan for the contents tag
+			for(const DataNode &dataNode : rootNode)
+				if(dataNode.Size() > 0 && dataNode.Token(0) == "contents")
+				{
+					// Savegame data gets written to the saves directory
+					// in a file with dataSetName as filename and with a .txt
+					// file extention.
+					// Other test-data might be injected in a different way,
+					// for example by direct loading into the relevant data
+					// structures.
+					DataWriter dataWriter(Files::Saves() + dataSetName + ".txt");
+					for(const DataNode &child : dataNode)
+						dataWriter.Write(child);
+
+					// Data was found and written. We are done succesfully.
+					return true;
+				}
+
+			// Content section was not found. (Should we just create an empty file here?)
+			return false;
+		}
+	
+	// Data-section was no longer found.
+	return false;
+}

--- a/source/TestData.h
+++ b/source/TestData.h
@@ -1,0 +1,43 @@
+/* TestData.h
+Copyright (c) 2019 by Peter van der Meer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+*/
+
+#ifndef TESTDATA_H_
+#define TESTDATA_H_
+
+#include <string>
+
+class DataNode;
+
+
+
+// Class representing a dataset for automated testing
+class TestData {
+public:
+	const std::string &Name() const;
+	void Load(const DataNode &node, const std::string &sourceDataFilePath);
+	// Function to inject the test-data into the game or into the games
+	// environment. Savegames would be written as file.
+	bool Inject() const;
+
+	// Types of datafiles that can be stored.
+	enum DataType {SAVEGAME};
+	
+private:
+	// Name of the dataset
+	std::string dataSetName;
+	// Type of the dataset
+	int dataSetType;
+	// File containing the test-data
+	std::string sourceDataFile;
+};
+
+#endif

--- a/tests/config/preferences.txt
+++ b/tests/config/preferences.txt
@@ -1,0 +1,23 @@
+"Automatic aiming" 1
+"Automatic firing" 1
+"help: bank" 1
+"help: basics 1" 1
+"help: basics 2" 1
+"help: dead" 1
+"help: disabled" 1
+"help: friendly disabled" 1
+"help: hiring" 1
+"help: jobs" 1
+"help: lost 1" 1
+"help: lost 2" 1
+"help: lost 3" 1
+"help: lost 4" 1
+"help: lost 5" 1
+"help: lost 6" 1
+"help: lost 7" 1
+"help: map" 1
+"help: multiple ships" 1
+"help: navigation" 1
+"help: outfitter" 1
+"help: stranded" 1
+"help: trading" 1

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+NUM_FAILED=0
+
+# Determine path of the current script
+HERE=$(cd `dirname $0` && pwd)
+RESOURCES=$(echo "${HERE}/.." | sed "s,/tests/..,,")
+
+# Determine paths to endless-sky executable and other relevant data
+ES_EXEC_PATH="${RESOURCES}/endless-sky"
+ES_CONFIG_TEMPLATE_PATH="${RESOURCES}/tests/config"
+
+if [ ! $? ]
+then
+	echo "Error: couldn't create temporary directory"
+	exit 1
+fi
+
+echo "***********************************************"
+echo "***         ES Autotest-runner              ***"
+echo "***********************************************"
+
+if [ ! -f "${ES_EXEC_PATH}" ]
+then
+	echo "Endless sky executable not found. Returning failure."
+	exit 1
+fi
+
+if [ ! -x "${ES_EXEC_PATH}" ]
+then
+	echo "Warning: Endless sky executable not executable. (did you use artifact downloading?)"
+	exit 1
+fi
+
+
+TESTS=$("${ES_EXEC_PATH}" --tests --resources "${RESOURCES}")
+if [ $? -ne 0 ]
+then
+	echo "Error could not retrieve testcases"
+	exit 1
+fi
+TESTS_OK=$(echo "${TESTS}" | grep -e "ACTIVE$" | cut -d$'\t' -f1)
+TESTS_NOK=$(echo "${TESTS}" | grep -e "KNOWN FAILURE$" -e "MISSING FEATURE$" | cut -d$'\t' -f1)
+echo ""
+
+#TODO: Allow running known-failures by default as well (to check if they accidentally got solved)
+echo "Tests not to execute (known failure or missing feature):"
+echo "${TESTS_NOK}"
+echo ""
+echo "Tests to execute:"
+echo "${TESTS_OK}"
+echo "***********************************************"
+
+# Set separator to newline (in case tests have spaces in their name)
+IFS_OLD=${IFS}
+IFS="
+"
+
+# Run all the tests
+for TEST in ${TESTS_OK}
+do
+	# Setup environment for the test
+	ES_CONFIG_PATH=$(mktemp --directory)
+	ES_SAVES_PATH="${ES_CONFIG_PATH}/saves"
+	mkdir -p "${ES_CONFIG_PATH}"
+	mkdir -p "${ES_SAVES_PATH}"
+	cp ${ES_CONFIG_TEMPLATE_PATH}/* ${ES_CONFIG_PATH}
+
+	TEST_RESULT="PASS"
+	echo "Running test \"${TEST}\" with ${ES_CONFIG_PATH}"
+	# Use pipefail and use sed to remove ALSA messages that appear due to missing soundcards in the CI environment
+	set -o pipefail
+	"$ES_EXEC_PATH" --resources "${RESOURCES}" --test "${TEST}" --config "${ES_CONFIG_PATH}" 2>&1 |\
+		sed -e "/^ALSA lib.*$/d" -e "/^AL lib.*$/d"
+	if [ $? -ne 0 ]
+	then
+		echo "errors.txt:"
+		cat "${ES_CONFIG_PATH}/errors.txt"
+		TEST_RESULT="FAIL"
+		NUM_FAILED=$((NUM_FAILED + 1))
+	fi
+	echo "Test \"${TEST}\": ${TEST_RESULT}"
+	echo ""
+done
+
+IFS=${IFS_OLD}
+
+if [ ${NUM_FAILED} -ne 0 ]
+then
+	echo "${NUM_FAILED} tests failed"
+	exit 1
+fi
+echo "All executed tests passed"
+exit 0

--- a/tests/run_tests_headless.sh
+++ b/tests/run_tests_headless.sh
@@ -41,7 +41,7 @@ echo "${GLXINFO}" | grep OpenGL
 # X11VNC_PID=$!
 # echo "X11VNC PID: ${X11VNC_PID}"
 
-../endless-sky --test "empty_testcase"
+./run_tests.sh
 RETURN_VALUE=$?
 
 kill -s SIGTERM ${XSERVER_PID}


### PR DESCRIPTION
**Feature:** This PR adds the auto-test framework for ES to ES-Stories

## Feature Details
Port from https://github.com/endless-sky/endless-sky/pull/4370
This adds the testframework and a small number of automated testcases that tests if the game still is working as intended.
The framework can already test a number of in-flight functions. Future updates should extend the support for on-planet actions as test-actions. And more tests can be added later to increase test-coverage.
See the original PR for more details.

## UI Screenshots
N/A

## Usage Examples
Run `./tests/run_tests.sh` in a cloned/checked out directory to run the tests.
Run `./endless-sky -h` to see other options.
