### PR TITLE
Fix paths in parse-test.

### DIFF
--- a/tests/test_parse.ps1
+++ b/tests/test_parse.ps1
@@ -14,8 +14,8 @@ if ($av)
 }
 # Remove any existing error files first.
 $FILEDIR = if ($IsWindows -or $Env:OS.ToLower().Contains('windows')) `
-           { "$env:APPDATA\endless-sky" } `
-           else { "$env:HOME/.local/share/endless-sky" };
+           { "$env:APPDATA\endless-sky-civil-war" } `
+           else { "$env:HOME/.local/share/endless-sky-civil-war" };
 $ERR_FILE = Join-Path -Path $FILEDIR -ChildPath "errors.txt";
 if (Test-Path -Path $ERR_FILE) { Remove-Item -Path $ERR_FILE; }
 

--- a/tests/test_parse.sh
+++ b/tests/test_parse.sh
@@ -6,11 +6,11 @@ if [ -z "$1" ]; then
 fi
 # OS Check
 if [[ $(uname) == 'Darwin' ]]; then
-  FILEDIR="$HOME/Library/Application Support/endless-sky"
+  FILEDIR="$HOME/Library/Application Support/endless-sky-civil-war"
 elif [[ $OSTYPE == 'msys' ]] || [[ $OS == 'Windows_NT' ]] || [[ ! -z ${APPDATA:-} ]]; then
-  FILEDIR="$APPDATA/endless-sky"
+  FILEDIR="$APPDATA/endless-sky-civil-war"
 else
-  FILEDIR="$HOME/.local/share/endless-sky"
+  FILEDIR="$HOME/.local/share/endless-sky-civil-war"
 fi
 ERR_FILE="$FILEDIR/errors.txt"
 


### PR DESCRIPTION
**Bugfix:** This PR fixes the paths in the parse-test

## Fix Details
The parse-test was not properly checking the error-log files due to paths being different between ES and ESCW. Now it is checking the error-log files.
Tested on Linux(Debian) only.
