### PR TITLE
Fix testframework for gamePanels UI input.

### DIFF
--- a/data/tests/tests_framework.txt
+++ b/data/tests/tests_framework.txt
@@ -27,7 +27,7 @@ test "Test-Framework - Load only"
 
 test "Test-Framework - UI controls"
 	status "Active"
-	description "Tests only loading of a game and then exits the game"
+	description "Tests if the in-game panels can be controlled by keypresses"
 	sequence
 		inject "commodity barges"
 		load "commodity barges.txt"
@@ -51,6 +51,23 @@ test "Test-Framework - UI controls"
 		"ui key" "h"
 		# Depart
 		"ui key" "d"
+
+
+test "Test-Framework - Menu controls"
+	status "Known Failure"
+	bug-id "None yet"
+	description "Tests if the in-game panels can be controlled by keypresses"
+	sequence
+		inject "commodity barges"
+		load "commodity barges.txt"
+		# Go to menu
+		"ui key" "escape"
+		# Go to settings
+		"ui key" "s"
+		# Go to controls
+		"ui key" "c"
+		# Enter ships
+		"ui key" "e"
 
 
 

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -519,8 +519,14 @@ Test::TestStep::TestResult Test::TestStep::Step(int stepAction, UI &menuPanels, 
 					return RESULT_FAIL;
 
 				const char* inputChar = stepInputString.c_str();
-				if(KeyInputToUI(gamePanels, inputChar))
+				if(PlayerMenuIsActive(menuPanels))
+				{
+					if(KeyInputToUI(menuPanels, inputChar))
+						return RESULT_DONE;
+				}
+				else if(KeyInputToUI(gamePanels, inputChar))
 					return RESULT_DONE;
+				
 				return RESULT_FAIL;
 			}
 			


### PR DESCRIPTION
**Feature:** This PR improves test-framework input handling for gamePanels and menuPanels.

## Feature Details
After this PR it should be possible to write testcases that give (basic) input to the UI.
Some inputs (like escape) that are handled in main.cpp cannot be given from the test-framework yet.

## UI Screenshots
N/A

## Usage Examples
Two testcases are included (one for the gamePanel that works, one for the menuPanel that is set to "known failure" and ignored by the automatic test-runs)
