### PR TITLE
Error file cleaning

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -581,7 +581,7 @@ ship "Modified Osprey"
 		"heat dissipation" .6
 		"fuel capacity" 625
 		"cargo space" 20
-		"outfit space" 625
+		"outfit space" 700
 		"weapon capacity" 150
 		"engine capacity" 230
 		"ramscoop" 2
@@ -595,7 +595,7 @@ ship "Modified Osprey"
 		"Plasma Cannon" 2
 		"Ion Cannon" 2
 
-		"D94-YV Shield Generator"
+		"D14-XL Shield Generator"
 		"Fusion Reactor"
 		"LP288a Battery Pack"
 		"Asteroid Scanner"

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -238,7 +238,7 @@ ship "Marauder Fury"
 		"heat dissipation" .85
 		"fuel capacity" 500
 		"cargo space" 15
-		"outfit space" 240
+		"outfit space" 254
 		"weapon capacity" 80
 		"engine capacity" 100
 		"ramscoop" 2
@@ -251,12 +251,12 @@ ship "Marauder Fury"
 		"Meteor Missile Launcher" 6
 		"Meteor Missile" 240
 
-		"D23-QP Shield Generator"
+		"D14-S Shield Generator"
 		"LP036a Battery Pack"
 		"Dwarf Core"
 		"Nerve Gas" 1
 		"Surveillance Pod"
-		"Water Coolant System"
+		"Water Coolant System MKI"
 		
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1781,8 +1781,8 @@ ship "Behemoth"
 		"heat dissipation" .4
 		"fuel capacity" 600
 		"cargo space" 490
-		"outfit space" 510
-		"weapon capacity" 280
+		"outfit space" 540
+		"weapon capacity" 298
 		"engine capacity" 90
 		"atmosphere scan" 10
 		weapon

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2536,7 +2536,7 @@ ship "Aerie"
 	outfits
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 136
-		"Meteor Missile Rack" 2
+		"Meteor Missile Box" 2
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -1512,8 +1512,8 @@ ship "Nest"
 		"heat dissipation" .67
 		"fuel capacity" 500
 		"cargo space" 40
-		"outfit space" 400
-		"weapon capacity" 140
+		"outfit space" 429
+		"weapon capacity" 168
 		"engine capacity" 80
 		"atmosphere scan" 10
 		weapon
@@ -1575,8 +1575,8 @@ ship "Roost"
 		"heat dissipation" .67
 		"fuel capacity" 600
 		"cargo space" 80
-		"outfit space" 450
-		"weapon capacity" 140
+		"outfit space" 479
+		"weapon capacity" 168
 		"engine capacity" 80
 		"atmosphere scan" 10
 		weapon
@@ -1643,8 +1643,8 @@ ship "Skein"
 		"heat dissipation" .71
 		"fuel capacity" 700
 		"cargo space" 120
-		"outfit space" 500
-		"weapon capacity" 140
+		"outfit space" 529
+		"weapon capacity" 168
 		"engine capacity" 80
 		"atmosphere scan" 10
 		weapon
@@ -2655,7 +2655,7 @@ ship "Challenger"
 		"heat dissipation" .7
 		"fuel capacity" 500
 		"cargo space" 40
-		"outfit space" 420
+		"outfit space" 425
 		"weapon capacity" 150
 		"engine capacity" 100
 		"atmosphere scan" 10
@@ -3144,8 +3144,8 @@ ship "Nomos"
 		"heat dissipation" .45
 		"fuel capacity" 600
 		"cargo space" 60
-		"outfit space" 760
-		"weapon capacity" 320
+		"outfit space" 790
+		"weapon capacity" 348
 		"engine capacity" 170
 		"atmosphere scan" 10
 		weapon
@@ -3420,8 +3420,8 @@ ship "Protector"
 		"heat dissipation" .6
 		"fuel capacity" 400
 		"cargo space" 50
-		"outfit space" 570
-		"weapon capacity" 220
+		"outfit space" 596
+		"weapon capacity" 250
 		"engine capacity" 100
 		"atmosphere scan" 10
 		weapon
@@ -3545,7 +3545,7 @@ ship "Vanguard"
 		"heat dissipation" .6
 		"fuel capacity" 400
 		"cargo space" 50
-		"outfit space" 560
+		"outfit space" 586
 		"weapon capacity" 220
 		"engine capacity" 120
 		"atmosphere scan" 10

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -2922,7 +2922,7 @@ ship "Astraea"
 		"heat dissipation" .65
 		"fuel capacity" 600
 		"cargo space" 50
-		"outfit space" 525
+		"outfit space" 556
 		"weapon capacity" 190
 		"engine capacity" 120
 		"atmosphere scan" 10

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -820,7 +820,7 @@ ship "Berserker"
 		"fuel capacity" 400
 		"cargo space" 10
 		"outfit space" 200
-		"weapon capacity" 35
+		"weapon capacity" 44
 		"engine capacity" 65
 		"cloak" .02
 		"cloaking energy" 5

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -3054,8 +3054,8 @@ ship "Arete"
 		"heat dissipation" .45
 		"fuel capacity" 700
 		"cargo space" 100
-		"outfit space" 820
-		"weapon capacity" 370
+		"outfit space" 859
+		"weapon capacity" 384
 		"engine capacity" 210
 		"atmosphere scan" 10
 		weapon

--- a/data/ships.txt
+++ b/data/ships.txt
@@ -701,8 +701,8 @@ ship "Caravel"
 		"heat dissipation" .7
 		"fuel capacity" 800
 		"cargo space" 55
-		"outfit space" 220
-		"weapon capacity" 40
+		"outfit space" 232
+		"weapon capacity" 55
 		"engine capacity" 100
 		"cloak" .02
 		"cloaking energy" 5

--- a/data/spaceport missions deep.txt
+++ b/data/spaceport missions deep.txt
@@ -2181,22 +2181,22 @@ mission "Deep: Scientist Rescue 2"
 
 
 
-ship "Bactrian" "Bactrian (Cosmic Devil)"
+ship "Bactrian" "Bactrian (Cosmic Devil)" #This is broken currently
 	outfits
-		"Inhibitor Cannon" 2
-		"Thrasher Turret" 4
-		"Point Defense Turret"
+		#"Inhibitor Cannon" 2
+		#"Thrasher Turret" 4
+		#"Point Defense Turret"
 		"Heavy Anti-Missile Turret"
-		"Boulder Reactor" 2
-		"Hai Ravine Batteries"
-		"Hai Chasm Batteries"
-		"Hai Diamond Regenerator"
+		#"Boulder Reactor" 2
+		#"Hai Ravine Batteries"
+		#"Hai Chasm Batteries"
+		#"Hai Diamond Regenerator"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 4
-		"Quantum Keystone"
+		#"Quantum Keystone"
 		"Ramscoop"
-		`"Bondir" Atomic Thruster`
-		`"Bufaer" Atomic Steering`
+		#`"Bondir" Atomic Thruster`
+		#`"Bufaer" Atomic Steering`
 		Hyperdrive
 
 

--- a/data/story republic navy.txt
+++ b/data/story republic navy.txt
@@ -120,7 +120,7 @@ mission "Republic Bounty 3"
 			`	"A ship called the <npc> has captured a number of wealthy merchants, and is demanding a ludicrous ransom. While this should not be a job for an ordinary contractor, they have made it clear they will kill the hostages if approached by one of our ships, we're calling his bluff indirectly. Your mission will be to disable the ship and leave it to the Republic for further actions. If he kills the hostages, he wont be able to blame the Republic for it."`
 			choice
 				`	"Don't worry, I majored in Crisis Aversion at University."`
-				`	"I'm in."`"
+				`	"I'm in."`
 					accept
 				`	"I'm sorry, but that's definetly above my pay grade."`
 					decline

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -435,7 +435,7 @@ ship "Challenger" "Challenger (Missile)"
 	outfits
 		"Torpedo Launcher" 2
 		"Torpedo" 60
-		"Sidewinder Missile Launcher" 2
+		"Ranger Missile Launcher" 2
 		"Sidewinder Missile" 159
 		"Sidewinder Missile Rack" 3
 		"Heavy Anti-Missile Turret" 2
@@ -448,8 +448,8 @@ ship "Challenger" "Challenger (Missile)"
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
 
@@ -510,7 +510,7 @@ ship "Nomos" "Nomos (Jump)"
 	outfits
 		"Typhoon Launcher" 2
 		"Typhoon Torpedo" 60
-		"Sidewinder Missile Launcher" 4
+		"Ranger Missile Launcher" 4
 		"Sidewinder Missile" 180
 		"Electron Turret" 3
 		"Heavy Anti-Missile Turret"
@@ -529,12 +529,12 @@ ship "Nomos" "Nomos (Jump)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Jump Drive"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 	gun "Typhoon Launcher"
 	gun "Typhoon Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 	turret "Electron Turret"
 	turret "Electron Turret"
 	turret "Electron Turret"
@@ -545,7 +545,7 @@ ship "Nomos" "Nomos (Mark II)"
 	outfits
 		"Typhoon Launcher" 2
 		"Typhoon Torpedo" 60
-		"Sidewinder Missile Launcher" 4
+		"Ranger Missile Launcher" 4
 		"Sidewinder Missile" 180
 		"Electron Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -563,10 +563,10 @@ ship "Nomos" "Nomos (Mark II)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Hyperdrive"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 	gun "Typhoon Launcher"
 	gun "Typhoon Launcher"
 	turret "Heavy Anti-Missile Turret"
@@ -1291,7 +1291,7 @@ ship "Odyssey" "Odyssey (Smuggler)"
 
 ship "Mule" "Mule (Heavy)"
 	outfits
-		"Sidewinder Missile Launcher"
+		"Ranger Missile Launcher"
 		"Sidewinder Missile" 45
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
@@ -1311,7 +1311,7 @@ ship "Mule" "Mule (Heavy)"
 
 ship "Nest" "Nest (Sidewinder)"
 	outfits
-		"Sidewinder Missile Launcher" 2
+		"Ranger Missile Launcher" 2
 		"Sidewinder Missile" 90
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -1375,7 +1375,7 @@ ship "Osprey" "Osprey (Missile)"
 
 ship "Protector" "Protector (Laser)"
 	outfits
-		"Sidewinder Missile Launcher" 2
+		"Ranger Missile Launcher" 2
 		"Sidewinder Missile" 90
 		"Anti-Missile Turret" 2
 		"Heavy Laser Turret" 4
@@ -1538,7 +1538,7 @@ ship "Raven" "Raven (Heavy)"
 
 ship "Roost" "Roost (Sidewinder)"
 	outfits
-		"Sidewinder Missile Launcher" 2
+		"Ranger Missile Launcher" 2
 		"Sidewinder Missile" 90
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -1573,7 +1573,7 @@ ship "Caravel" "Caravel (Speedy)"
 
 ship "Skein" "Skein (Sidewinder)"
 	outfits
-		"Sidewinder Missile Launcher" 2
+		"Ranger Missile Launcher" 2
 		"Sidewinder Missile" 90
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -1683,7 +1683,7 @@ ship "Star Barge" "Star Barge (Armed)"
 
 ship "Vanguard" "Vanguard (Missile)"
 	outfits
-		"Sidewinder Missile Launcher" 4
+		"Ranger Missile Launcher" 4
 		"Sidewinder Missile" 295
 		"Sidewinder Missile Rack" 5
 		"Heavy Rocket Launcher" 3
@@ -1703,10 +1703,10 @@ ship "Vanguard" "Vanguard (Missile)"
 	gun "Heavy Rocket Launcher"
 	gun "Heavy Rocket Launcher"
 	gun "Heavy Rocket Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 
 
 ship "Vanguard" "Vanguard (Particle)"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1459,8 +1459,36 @@ ship "Quicksilver" "Quicksilver (Scanner)"
 
 
 ship "Achlys" "Achlys (Mark II)"
+	attributes
+		category "Frigate"
+		licenses
+			Navy
+		"cost" 1580000
+		"shields" 3500
+		"hull" 1200
+		"hull repair rate" .1
+		"landing gear" 1
+		"required crew" 7
+		"bunks" 14
+		"mass" 80
+		"drag" 3.8
+		"heat dissipation" .6
+		"fuel capacity" 500
+		"cargo space" 25
+		"outfit space" 287
+		"weapon capacity" 116
+		"engine capacity" 50
+		"cloak" .02
+		"cloaking energy" 5
+		"cloaking heat" 200
+		"atmosphere scan" 10
+		weapon
+			"blast radius" 40
+			"shield damage" 400
+			"hull damage" 200
+			"hit force" 600
 	outfits
-		"Sidewinder Missile Launcher" 4
+		"Ranger Missile Launcher" 4
 		"Sidewinder Missile" 180
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
@@ -1469,12 +1497,10 @@ ship "Achlys" "Achlys (Mark II)"
 		"A120 Atomic Thruster"
 		"A125 Atomic Steering"
 		"Scram Drive"
-	gun
-	gun
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 
 
 

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1220,7 +1220,7 @@ ship "Manta" "Manta (Proton)"
 
 
 
-ship "Modified Argosy" "Modified Argosy (Blaster)"
+ship "Odyssey" "Odyssey (Blaster)"
 	outfits
 		"Modified Blaster" 4
 		"Quad Blaster Turret"
@@ -1237,7 +1237,7 @@ ship "Modified Argosy" "Modified Argosy (Blaster)"
 		"Hyperdrive"
 
 
-ship "Modified Argosy" "Modified Argosy (Heavy)"
+ship "Odyssey" "Odyssey (Heavy)"
 	outfits
 		"Heavy Laser" 4
 		"Heavy Laser Turret"
@@ -1253,7 +1253,7 @@ ship "Modified Argosy" "Modified Argosy (Heavy)"
 		"Hyperdrive"
 
 
-ship "Modified Argosy" "Modified Argosy (Missile)"
+ship "Odyssey" "Odyssey (Missile)"
 	outfits
 		"Meteor Missile Launcher" 2
 		"Meteor Missile" 105
@@ -1273,7 +1273,7 @@ ship "Modified Argosy" "Modified Argosy (Missile)"
 		"Hyperdrive"
 
 
-ship "Modified Argosy" "Modified Argosy (Smuggler)"
+ship "Odyssey" "Odyssey (Smuggler)"
 	outfits
 		"Beam Laser" 4
 		"Heavy Laser Turret"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -178,7 +178,7 @@ ship "Behemoth" "Behemoth (Heavy)"
 
 ship "Behemoth" "Behemoth (Proton)"
 	outfits
-		"Sidewinder Missile Launcher" 2
+		"Ranger Missile Launcher" 2
 		"Sidewinder Missile" 90
 		"Proton Turret" 4
 		"Heavy Anti-Missile Turret" 2
@@ -202,7 +202,7 @@ ship "Behemoth" "Behemoth (Proton)"
 
 ship "Behemoth" "Behemoth (Speedy)"
 	outfits
-		"Sidewinder Missile Launcher" 2
+		"Ranger Missile Launcher" 2
 		"Sidewinder Missile" 90
 		"Heavy Laser Turret" 6
 		"Breeder Reactor"
@@ -237,7 +237,7 @@ ship "Berserker" "Berserker (Strike)"
 	outfits
 		"Torpedo Launcher"
 		"Torpedo" 20
-		"Sidewinder Missile Launcher"
+		"Ranger Missile Launcher"
 		"Sidewinder Missile" 45
 		"nGVF-CC Fuel Cell"
 		"Supercapacitor"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -154,7 +154,7 @@ ship "Bastion" "Bastion (Scanner)"
 ship "Behemoth" "Behemoth (Heavy)"
 	outfits
 		"Heavy Rocket Launcher" 2
-		Heavy Rocket 60
+		"Heavy Rocket" 60
 		"Quad Blaster Turret" 2
 		"Plasma Turret" 2
 		"Heavy Anti-Missile Turret" 2

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1557,7 +1557,7 @@ ship "Caravel" "Caravel (Speedy)"
 	outfits
 		"Meteor Missile Launcher"
 		"Meteor Missile" 30
-		"Sidewinder Missile Launcher"
+		"Ranger Missile Launcher"
 		"Sidewinder Missile" 45
 		"Anti-Missile Turret"
 		"NT-200 Nucleovoltaic"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -320,7 +320,7 @@ ship "Bulk Freighter" "Bulk Freighter (Proton)"
 ship "Arete" "Arete (Jump)"
 	outfits
 		"Particle Cannon" 4
-		"Sidewinder Missile Launcher" 4
+		"Ranger Missile Launcher" 4
 		"Sidewinder Missile" 180
 		"Electron Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -342,12 +342,12 @@ ship "Arete" "Arete (Jump)"
 		"Jump Drive"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 	turret "Heavy Anti-Missile Turret"
 	turret "Electron Turret"
 	turret "Heavy Anti-Missile Turret"
@@ -357,7 +357,7 @@ ship "Arete" "Arete (Jump)"
 ship "Arete" "Arete (Mark II)"
 	outfits
 		"Particle Cannon" 4
-		"Sidewinder Missile Launcher" 4
+		"Ranger Missile Launcher" 4
 		"Sidewinder Missile" 180
 		"Electron Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -378,12 +378,12 @@ ship "Arete" "Arete (Mark II)"
 		"Hyperdrive"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
+	gun "Ranger Missile Launcher"
+	gun "Ranger Missile Launcher"
 	turret "Heavy Anti-Missile Turret"
 	turret "Electron Turret"
 	turret "Heavy Anti-Missile Turret"


### PR DESCRIPTION
Even more cleaning of the error file. Mainly changing some outfits to their new names, but also makes some balance changes to keep away the outfit space errors. This is a bit of a bandaid solution and these ships that got the outfit space changed should be looked over by someone who actually knows how to balance ships and properly change it so that they are balanced and don't make the game scream at people.

Currently these ships are:
Marauder Fury
Modified Osprey
Astraea
Achlys Mark II
Arete
Behemoth
Berserker
Caravel
Challenger
Nest
Nomos
Protector
Roost
Skein

The files with broken diffs are `spaceport missions deep` and `story republic navy`
in spaceport missions deep, the change was a bunch of commenting out on the Cosmic Devil.
In story republic navy, the change was removing a " from line 157.