### PR TITLE
Add string header

### DIFF
--- a/source/Panel.h
+++ b/source/Panel.h
@@ -17,6 +17,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include <functional>
 #include <list>
+#include <string>
 
 #include <SDL2/SDL.h>
 


### PR DESCRIPTION
Fixes failing builds with GCC 10

**Bugfix:** This PR addresses issue #N/A

## Fix Details
Fixes failing build with the most recent version of GCC by adding the string include to Panel.h.
