### PR TITLE
Give Heavy Shuttle cloaking capabilities

### DIFF
--- a/data/ships.txt
+++ b/data/ships.txt
@@ -659,6 +659,9 @@ ship "Heavy Shuttle"
 		"outfit space" 120
 		"weapon capacity" 10
 		"engine capacity" 60
+		"cloak" .02
+		"cloaking energy" 5
+		"cloaking heat" 100
 		"atmosphere scan" 10
 		weapon
 			"blast radius" 12


### PR DESCRIPTION
Xyma from Discord mentioned that the Heavy Shuttle did not have cloak. This PR gives it one. Waiting on a merge from @kikotheexile, as I do not yet know if this was an intentional choice or not.