### PR TITLE
Fix for Copyright changes

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Build Application
         run: scons -j $(nproc)
       - name: Package Application
-        run: tar -czf ${{ env.OUTPUT }} sounds images/ data/ fonts/ license.txt keys.txt icon.png endless-sky credits.txt copyright changelog
+        run: tar -czf ${{ env.OUTPUT }} sounds images/ data/ fonts/ license.txt keys.txt icon.png endless-sky credits.txt copyright.txt changelog
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
Copyright file was renamed copyright.txt, but this was never updated as well.

https://github.com/kikotheexile/Endless-Sky-Civil-War/commit/6c3f235671d5e71424c1ba7a21cfa97add88c7fe was changed here.

Prior commit showed it compiled the Ubuntu version fine. https://github.com/kikotheexile/Endless-Sky-Civil-War/actions/runs/273646383

Only change was the addition of `.txt` to the copyright file, which this PR does to the yaml tar command.