### PR TITLE
Adds missing Uninhabited government

### DIFF
--- a/data/resources/governments.txt
+++ b/data/resources/governments.txt
@@ -502,3 +502,7 @@ government "Test Dummy"
 	"player reputation" -1000
 	"hostile hail" "test dummy"
 	"hostile disabled hail" "disabled test dummy"
+
+# Uninhabited Space
+government "Uninhabited"
+	color 0.5 0.5 0.5


### PR DESCRIPTION
Fix for the bright white color of uninhabited government systems.  Seems that the lack of entry resulted in the code using default 1 values for the RGB color, resulting in white.