### PR TITLE
Apply formation flying during landing.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1812,9 +1812,15 @@ void AI::MoveEscort(Ship &ship, Command &command)
 	{
 		ship.SetTargetSystem(nullptr);
 		ship.SetTargetStellar(parent.GetTargetStellar());
-		MoveToPlanet(ship, command);
 		if(parent.IsLanding() || parent.CanLand())
+		{
+			MoveToPlanet(ship, command);
 			command |= Command::LAND;
+		}
+		else if(ship.GetFormationPattern())
+			MoveInFormation(ship, command);
+		else
+			KeepStation(ship, command, parent);
 	}
 	else if(parent.Commands().Has(Command::BOARD) && parent.GetTargetShip().get() == &ship)
 		Stop(ship, command, .2);


### PR DESCRIPTION
**Feature:** This PR ensures that NPCs also form formations during landing.

## Feature Details
Old behavior was that NPCs would just rush to the planet as fast as possible. After this PR the NPCs try to form a formation during landing.

## UI Screenshots
N/A

## Usage Examples
N/A (formations are already set)