### PR TITLE
Fix crash when displaying faction flags on macOS

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -986,7 +986,7 @@ void Engine::Draw() const
 	{
 		SpriteShader::Draw(
 			SpriteSet::Get("flags/"+info.GetString("target government").first),
-			interface->GetPoint("faction flag") + Point(0, 0),
+			interface->GetPoint("faction flag"),
 			1.,
 			targetSwizzle
 		);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -713,7 +713,6 @@ void Engine::Step(bool isActive)
 		else
 			info.SetString("target government", target->GetGovernment()->GetName());
 		targetSwizzle = target->GetSwizzle();
-		targetFlag = target->GetSwizzle();
 		info.SetString("mission target", target->GetPersonality().IsTarget() ? "(mission target)" : "");
 		
 		int targetType = RadarType(*target, step);
@@ -981,15 +980,18 @@ void Engine::Draw() const
 		for(int i = 0; i < 2; ++i)
 			SpriteShader::Draw(mark[i], center + Point(dx[i], 0.), 1., targetSwizzle);
 	}
-	// Draw the faction flags.
-	if(targetFlag >= 0 && interface->HasPoint("faction flag"))
+	
+	// Draw the faction flag.
+	if(targetSwizzle >= 0 && interface->HasPoint("faction flag"))
 	{
-		Point center = interface->GetPoint("faction flag");
-
-		const Sprite *mark[1] = {SpriteSet::Get("flags/"+info.GetString("target government").first)};
-		for(int i = 0; i < 2; ++i)
-			SpriteShader::Draw(mark[i], center + Point(0, 0), 1., targetSwizzle);
+		SpriteShader::Draw(
+			SpriteSet::Get("flags/"+info.GetString("target government").first),
+			interface->GetPoint("faction flag") + Point(0, 0),
+			1.,
+			targetSwizzle
+		);
 	}
+	
 	if(jumpCount && Preferences::Has("Show mini-map"))
 		MapPanel::DrawMiniMap(player, .5f * min(1.f, jumpCount / 30.f), jumpInProgress, step);
 	

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -178,7 +178,6 @@ private:
 	Point targetVector;
 	Point targetUnit;
 	int targetSwizzle = -1;
-	int targetFlag = -1;
 	EscortDisplay escorts;
 	std::vector<Status> statuses;
 	std::vector<PlanetLabel> labels;


### PR DESCRIPTION
### Context

My game crashed whenever I targeted a ship when playing on macOS.

We first thought that this had something to do with the High DPI code,
as that's the line that eventually throw the error. However, hard coding
the High DPI setting to `false` did not prevent the crash. This prompted
us to investigate more deeply.

The actual error was an `EXC_BAD_ACCESS` exception. This happens when we
try to access a memory location that has already been released. From
what we can tell, macOS has stricter policies around memory access,
which is probably why it didn't crash on other operating systems.

We eventually figured out that the crash was caused by the code that
draws a faction flag for the currently targeted ship. This code read a
single flag into a collection, then tried to iterate over that collection
and display two of them.

### Changes

This commit allows the game to display faction flags without crashing on
macOS. It also makes that code run more quickly and use less memory.
