### PR TITLE
Fix FleetSummary crash when player has no ships

### DIFF
--- a/source/Crew.cpp
+++ b/source/Crew.cpp
@@ -62,6 +62,8 @@ int64_t Crew::CalculateSalaries(const vector<shared_ptr<Ship>> &ships, const Shi
 {
 	int64_t totalSalaries = 0;
 
+	if(!flagship) return totalSalaries;
+
 	for(const shared_ptr<Ship> &ship : ships)
 	{
 		totalSalaries += Crew::SalariesForShip(

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -531,6 +531,7 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 		vector<pair<int64_t, string>> fleetSummary = Crew::FleetSummary(player);
 		DrawList(fleetSummary, table, "fleet summary: ");
 	}
+	
 	// Other special information:
 	auto salary = Match(player, "salary: ", "");
 	sort(salary.begin(), salary.end());

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -527,9 +527,10 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 	}
 	
 	// Fleet summary:
-	vector<pair<int64_t, string>> fleetSummary = Crew::FleetSummary(player);
-	DrawList(fleetSummary, table, "fleet summary: ");
-	
+	if(player.Flagship()) {
+		vector<pair<int64_t, string>> fleetSummary = Crew::FleetSummary(player);
+		DrawList(fleetSummary, table, "fleet summary: ");
+	}
 	// Other special information:
 	auto salary = Match(player, "salary: ", "");
 	sort(salary.begin(), salary.end());


### PR DESCRIPTION
### Context

The game crashed when a player opened the Player Info Panel (I) without
any ships. This typically happened if someone exited the shipyard at the
start of the game without buying anything, then tried to view their
logbook.

### Changes

This commit prevents the game from crashing when viewing the Player Info
Panel without any ships. The easiest fix was to not show the Fleet
Summary if the player doesn't have a fleet.
