### PR TITLE
Overhaul crew data and associated documentation

### DIFF
--- a/data/missions/intro conversations.txt
+++ b/data/missions/intro conversations.txt
@@ -130,22 +130,24 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crew
-	`	Most ships will have room to hire additional crew, or will require more than one crewman to run the ship. Each Crewman not only requires their own salary, but also is given ship shares. Salaries vary based on the rank of the crewman, as do their shares. More expensive crewmen will be required with the more crew you have.`
-	`	A breakdown of the crew is as follows, in order of salary drawn:`
+	`	Most ships will have room to hire additional crew, or will require more than one crew member to run the ship. Each crew member expects a daily salary, and they receive some of the fleet's profits. Salaries vary based on the rank of the crew member, as do their fleet shares. The more crew a given ship has, the more officers it requires, and the higher those officers need to be in rank. High ranking officers draw heavy salaries and have greater shares in the fleet's profits.
+	`	A breakdown of the crew is as follows, in order of daily salary:`
 	choice	
-		`	You: No salary, 1,000 ship shares.`
+		`	You: No salary, 100 fleet shares.`
 			goto crewyou
-		`	Regular Crewmen: 100 credits per day, 1 ship share.`
+		`	Regular Crew: 100 credits per day, 1 fleet share.`
 			goto crewreg
-		`	Pilots: 250 credits per day, 20 ship shares.`
+		`	Pilots: 1,000 credits per day, 20 fleet shares.`
 			goto crewpilot
-		`	Junior Officers: 500 credits per day, 10 ship shares.`
+		`	Junior Officers: 500 credits per day, 10 fleet shares.`
 			goto crewjo
-		`	Senior Officers: 1,000 credits per day, 50 ship shares.`
-			goto crewco
+		`	Senior Officers: 2,000 credits per day, 20 fleet shares.`
+			goto crewso
+		`	Executive Officers: 10,000 credits per day, 50 fleet shares.`
+			goto crewxo
 		`	Credits per day?`
 			goto crewcredits
-		`	Ship shares?`
+		`	Fleet shares?`
 			goto crewshares
 		`	(Back to Basics.)`
 			goto basics
@@ -154,8 +156,8 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewyou
-	`	You are a crewman aboard your own ship, with all the rights and privileges that brings. However, you are also the boss. Meaning you get treated a little differently.`
-	`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 1,000 ship shares. Meaning you should always get the lion's share of any profits.`
+	`	You are a crew member on your flagship, with all the rights and privileges that brings. However, since you are also in charge, you get treated quite differently.`
+	`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 	choice	
 		`	(Back to the Crew overview.)`
 			goto crew
@@ -166,9 +168,9 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewreg
-	`	Ships often need different crew members to handle different duties. Be it filling in as hospitality staff for luxury accommodations, manning the guns, or providing extra ship security`
-	`	Your most common crewmen, the "Regulars," handle these jobs. They also cost the least. Drawing 100 credit salaries per day, and only taking one ship share each.`
-	`	Some, more cruel, captains have been known to throw hoards of their regulars at hostile ships in boarding operations. This is seen as distasteful, and is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or regulating this, and will not require you to provide hazard pay.`
+	`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
+	`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least, each drawing a salary of 100 credits per day and only taking one share in the fleet's profits.`
+	`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 	choice	
 		`	(Back to the Crew overview.)`
 			goto crew
@@ -179,8 +181,8 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewpilot
-	`	Pilots are who you rely upon most to manage other ships in your fleet. Be they high-risk fighter jockeys, or the people running your heavy escorts. Their job is to fly any ships that you don't, and they get paid extra for it.`
-	`	Although Pilots take your place aboard any ship you aren't currently flying, they do not actually take on the responsibility of being a Captain, and will seldom act independently of you. They will do their best to your orders to the letter when possible.`
+	`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it: 500 credits per day, and 10 fleet shares.`
+	`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have on any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 	choice	
 		`	(Back to the Crew overview.)`
 			goto crew
@@ -191,8 +193,8 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewjo
-	`	These officers manage teams of about five regular crewmen, and you will automatically hire one for ever five crewmen you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less ship shares.`
-	`	Junior Officers are required by both law and moral codes of conduct for every five crewmen aboard any ship. Even Pirates, who mostly run on slave labor, abide by the rules requiring officers. Although it is suspected Pirate crews abide by this largely due to improved performance.`
+	`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but a little safer than those of your pilots, so they draw a heavier salary of 1,000 credits per day, but take only 5 shares of any profit.`
+	`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 	choice	
 		`	(Back to the Crew overview.)`
 			goto crew
@@ -202,9 +204,21 @@ conversation "intro"
 			goto menu
 		`	(Continue to the intro.)`
 			goto logbook
-	label crewco
-	`	The largest ships and fleets will need Senior Officers. Experienced managers who can efficiently run large groups of crewmen and direct them.`
-	`	Senior Officers are required by both law and moral codes of conduct for every twenty crewmen aboard any ship. Even Pirates, who mostly run on slave labor, abide by the rules requiring officers. Although it is suspected Pirate crews abide by this largely due to improved performance.`
+	label crewso
+	`	Large ships require Senior Officers to operate the bridge and coordinate the Junior Officers that serve under them. These crew members are experienced decision makers who have command experience, and they usually know their ship inside out. Many are former ship captains that have opted for employment as a less risky way to earn a living. You pay them well: 2,000 credits per day and 20 shares in the fleet's profits.`
+	`	You will automatically hire one Senior Officer for every 20 crew members aboard a given ship.`
+	choice	
+		`	(Back to the Crew overview.)`
+			goto crew
+		`	(Back to Basics.)`
+			goto basics
+		`	(Back to Menu.)`
+			goto menu
+		`	(Continue to the intro.)`
+			goto logbook
+	label crewxo
+	`	Commanding a heavy warship, city ship, or similarly huge vessel is no easy task; it normally requires someone with years of training and experience. These people are hard to come by, and they charge a lot for their services. You pay each of them 5,000 credits per day and 50 shares in the fleet's profits.`
+	`	You will automatically hire one Executive Officer to command each ship that has at least 50 crew members.`
 	choice	
 		`	(Back to the Crew overview.)`
 			goto crew
@@ -217,7 +231,7 @@ conversation "intro"
 	label crewcredits
 	`	Each crew member is required by law to be paid a minimum wage based on their position. These wages are to be paid out daily, and will be automatically deducted from your account every day through the Universal Credit System.`
 	`	The Universal Credit System is managed by an alien species known as the Quarg. According to them, these same credits are accepted by every "Tier One or higher" civilization in the known universe. Although there was a lot of political resistance in the early days of the Human exploration, the UCS "Bank" has been accepted and used by every human government for centuries.`
-	`	This means that you could theoretically hire crewmen on an alien planet, and they would automatically be paid just the same as their human counterparts.`
+	`	This means that you could theoretically hire crew members on an alien planet, and they would automatically be paid the same as their human counterparts.`
 	choice	
 		`	(Back to the Crew overview.)`
 			goto crew
@@ -228,9 +242,9 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewshares
-	`	Each crew member is entitled to profit sharing for working aboard your ship, and thus holds a "share."`
-	`	As the Captain, you get 1,000 shares. Meaning you get the same amount of profit as 1,000 regular crew members would, making sure that you can continue to afford to buy new stock, outfits, and pay out crew salaries.`
-	`	Different crew members are given different shares based on the risks and responsibilities they take on. More valuable crew members, namely Pilots and Senior Officers, will get more shares of your total profits.`
+	`	Each crew member is entitled to a share of your fleet's profits, and thus holds one or more 'shares'.`
+	`	As the leader of the fleet, you get 100 shares. This means that you get the same amount of profit as 100 regular crew members. You also own all of the ships, outfits, and cargo. Even in a large fleet, no other individual crew member will ever have more fleet shares than you do.`
+	`	Each kinds of crew member is given a different number of fleet shares, based on the risks and responsibilities they take on. While you are definitely in charge, your most senior crew members allow you to command an arbitrarily large fleet without becoming lost in a sea of petty concerns. In return, they receive a significant share of any profits that you make together.`
 	choice
 		`	(Back to the Crew overview.)`
 			goto crew

--- a/data/missions/intro missions.txt
+++ b/data/missions/intro missions.txt
@@ -71,28 +71,32 @@ mission "Trust fund baby"
 			`	The main default keys you will use in combat are your arrow keys to move, (Tab) to fire your primary weapon, (W) to select your secondary weapon, and (Q) to fire your secondary weapon.`
 			`	Check Preferences by pressing the (ESC) key for more details.`
 		log "0: Manual" "Crew Basics" `The crew breakdown is as follows:`
-			`	You: No salary, 1,000 ship shares.`
-			`	You are a crewman aboard your own ship, with all the rights and privileges that brings. However, you are also the boss. Meaning you get treated a little differently.`
-			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 1,000 ship shares. Meaning you should always get the lion's share of any profits.`
+			`	You: No salary, 100 fleet shares.`
+			`	You are part of the crew of your own ship, with all the rights and privileges that brings. However, you are also in charge, so you get treated quite differently.`
+			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 			``
-			`	Regular Crewmen: 100 credits per day, 1 ship share.`
-			`	Ships often need different crew members to handle different duties. Be it filling in as hospitality staff for luxury accommodations, manning the guns, or providing extra ship security`
-			`	Your most common crewmen, the "Regulars," handle these jobs. They also cost the least. Drawing 100 credit salaries per day, and only taking one ship share each.`
-			`	Some, usually cruel, captains have been known to throw hoards of their Regulars at hostile ships in boarding operations. This is seen as distasteful, and is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or regulating this, and will not require you to provide hazard pay.`
+			`	Regular Crew: 100 credits per day, 1 fleet share.`
+			`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
+			`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least.`
+			`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 			``
-			`	Pilots: 250 credits per day, 20 ship shares.`
-			`	Pilots are who you rely upon most to manage other ships in your fleet. Be they high-risk fighter jockeys, or the people running your heavy escorts. Their job is to fly any ships that you don't, and they get paid extra for it.`
-			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not actually take on the responsibility of being a Captain, and will seldom act independently of you. They will do their best to your orders to the letter when possible.`
+			`	Pilots: 500 credits per day, 10 fleet shares.`
+			`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it.`
+			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 			``
-			`	Even Pirates, who mostly run on slave labor, abide by the rules requiring officers. Although it is suspected Pirate crews abide by this largely due to improved performance.`
+			`	Even Pirates that utilise slave labor abide by the laws requiring officers. That said, many suspect that Pirate crews do it simply because they can't run their ships effectively without them.`
 			``
-			`	Junior Officers: 500 credits per day, 10 ship shares.`
-			`	These officers manage teams of about five regular crewmen, and you will automatically hire one for ever five crewmen you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less ship shares.`
-			`	Junior Officers are required by both law and moral codes of conduct for every five crewmen aboard any ship.`
+			`	Junior Officers: 1000 credits per day, 5 fleet shares.`
+			`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less fleet shares.`
+			`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 			``
-			`	Senior Officers: 1,000 credits per day, 50 ship shares.`
-			`	The largest ships and fleets will need Senior Officers. Experienced managers who can efficiently run large groups of crewmen and direct them.`
-			`	Senior Officers are required by both law and moral codes of conduct for every twenty crewmen aboard any ship.`
+			`	Senior Officers: 2,000 credits per day, 20 fleet shares.`
+			`	Large ships require Senior Officers to operate the bridge and coordinate the Junior Officers that serve under them. These crew members are experienced decision makers who have command experience and know their ship inside out. Many are former ship captains that have opted for employment as a less risky way to earn a living.`
+			`	You will automatically hire one Senior Officer for every 20 crew members aboard a given ship.`
+			``
+			`	Executive Officers: 10,000 credits per day, 50 fleet shares.`
+			`	Commanding a heavy warship, city ship, or similarly huge vessel is no easy task; it normally requires someone with years of training and experience. These people are hard to come by, and they charge a lot for their services.`
+			`	You will automatically hire one Executive Officer to command each ship that has at least 50 crew members.`
 		log "Factions" "Republic" `Hundreds of years ago, the independent territories in different parts of human space agreed to join together into a single democratic government, with Earth as its capital. The rise of the Republic ushered in a long period of peace and prosperity in human history.`
 			`Representation in the Republic Parliament is based on population. That means that some individual "Paradise Worlds" have more representatives than entire regions of space like the Dirt Belt that are more sparsely settled.`
 		log "Factions" "Syndicate" `The Syndicate is a mega-corporation, the largest employer in human space. People who cannot find steady work elsewhere flock to the Syndicate factory worlds, where they are almost guaranteed to find a job. Although the Syndicate is technically part of the Republic, Syndicate worlds are governed directly by the corporation.`
@@ -176,28 +180,32 @@ mission "Perfectly Vanilla"
 			`	The main default keys you will use in combat are your arrow keys to move, (Tab) to fire your primary weapon, (W) to select your secondary weapon, and (Q) to fire your secondary weapon.`
 			`	Check Preferences by pressing the (ESC) key for more details.`
 		log "0: Manual" "Crew Basics" `The crew breakdown is as follows:`
-			`	You: No salary, 1,000 ship shares.`
-			`	You are a crewman aboard your own ship, with all the rights and privileges that brings. However, you are also the boss. Meaning you get treated a little differently.`
-			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 1,000 ship shares. Meaning you should always get the lion's share of any profits.`
+			`	You: No salary, 100 fleet shares.`
+			`	You are part of the crew of your own ship, with all the rights and privileges that brings. However, you are also in charge, so you get treated quite differently.`
+			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 			``
-			`	Regular Crewmen: 100 credits per day, 1 ship share.`
-			`	Ships often need different crew members to handle different duties. Be it filling in as hospitality staff for luxury accommodations, manning the guns, or providing extra ship security`
-			`	Your most common crewmen, the "Regulars," handle these jobs. They also cost the least. Drawing 100 credit salaries per day, and only taking one ship share each.`
-			`	Some, usually cruel, captains have been known to throw hoards of their Regulars at hostile ships in boarding operations. This is seen as distasteful, and is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or regulating this, and will not require you to provide hazard pay.`
+			`	Regular Crew: 100 credits per day, 1 fleet share.`
+			`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
+			`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least.`
+			`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 			``
-			`	Pilots: 250 credits per day, 20 ship shares.`
-			`	Pilots are who you rely upon most to manage other ships in your fleet. Be they high-risk fighter jockeys, or the people running your heavy escorts. Their job is to fly any ships that you don't, and they get paid extra for it.`
-			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not actually take on the responsibility of being a Captain, and will seldom act independently of you. They will do their best to your orders to the letter when possible.`
+			`	Pilots: 500 credits per day, 10 fleet shares.`
+			`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it.`
+			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 			``
-			`	Even Pirates, who mostly run on slave labor, abide by the rules requiring officers. Although it is suspected Pirate crews abide by this largely due to improved performance.`
+			`	Even Pirates that utilise slave labor abide by the laws requiring officers. That said, many suspect that Pirate crews do it simply because they can't run their ships effectively without them.`
 			``
-			`	Junior Officers: 500 credits per day, 10 ship shares.`
-			`	These officers manage teams of about five regular crewmen, and you will automatically hire one for ever five crewmen you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less ship shares.`
-			`	Junior Officers are required by both law and moral codes of conduct for every five crewmen aboard any ship.`
+			`	Junior Officers: 1000 credits per day, 5 fleet shares.`
+			`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less fleet shares.`
+			`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 			``
-			`	Senior Officers: 1,000 credits per day, 50 ship shares.`
-			`	The largest ships and fleets will need Senior Officers. Experienced managers who can efficiently run large groups of crewmen and direct them.`
-			`	Senior Officers are required by both law and moral codes of conduct for every twenty crewmen aboard any ship.`
+			`	Senior Officers: 2,000 credits per day, 20 fleet shares.`
+			`	Large ships require Senior Officers to operate the bridge and coordinate the Junior Officers that serve under them. These crew members are experienced decision makers who have command experience and know their ship inside out. Many are former ship captains that have opted for employment as a less risky way to earn a living.`
+			`	You will automatically hire one Senior Officer for every 20 crew members aboard a given ship.`
+			``
+			`	Executive Officers: 10,000 credits per day, 50 fleet shares.`
+			`	Commanding a heavy warship, city ship, or similarly huge vessel is no easy task; it normally requires someone with years of training and experience. These people are hard to come by, and they charge a lot for their services.`
+			`	You will automatically hire one Executive Officer to command each ship that has at least 50 crew members.`
 		log "Factions" "Republic" `Hundreds of years ago, the independent territories in different parts of human space agreed to join together into a single democratic government, with Earth as its capital. The rise of the Republic ushered in a long period of peace and prosperity in human history.`
 			`Representation in the Republic Parliament is based on population. That means that some individual "Paradise Worlds" have more representatives than entire regions of space like the Dirt Belt that are more sparsely settled.`
 		log "Factions" "Syndicate" `The Syndicate is a mega-corporation, the largest employer in human space. People who cannot find steady work elsewhere flock to the Syndicate factory worlds, where they are almost guaranteed to find a job. Although the Syndicate is technically part of the Republic, Syndicate worlds are governed directly by the corporation.`
@@ -277,28 +285,32 @@ mission "A pirate's life!"
 			`	The main default keys you will use in combat are your arrow keys to move, (Tab) to fire your primary weapon, (W) to select your secondary weapon, and (Q) to fire your secondary weapon.`
 			`	Check Preferences by pressing the (ESC) key for more details.`
 		log "0: Manual" "Crew Basics" `The crew breakdown is as follows:`
-			`	You: No salary, 1,000 ship shares.`
-			`	You are a crewman aboard your own ship, with all the rights and privileges that brings. However, you are also the boss. Meaning you get treated a little differently.`
-			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 1,000 ship shares. Meaning you should always get the lion's share of any profits.`
+			`	You: No salary, 100 fleet shares.`
+			`	You are part of the crew of your own ship, with all the rights and privileges that brings. However, you are also in charge, so you get treated quite differently.`
+			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 			``
-			`	Regular Crewmen: 100 credits per day, 1 ship share.`
-			`	Ships often need different crew members to handle different duties. Be it filling in as hospitality staff for luxury accommodations, manning the guns, or providing extra ship security`
-			`	Your most common crewmen, the "Regulars," handle these jobs. They also cost the least. Drawing 100 credit salaries per day, and only taking one ship share each.`
-			`	Some, usually cruel, captains have been known to throw hoards of their Regulars at hostile ships in boarding operations. This is seen as distasteful, and is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or regulating this, and will not require you to provide hazard pay.`
+			`	Regular Crew: 100 credits per day, 1 fleet share.`
+			`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
+			`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least.`
+			`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 			``
-			`	Pilots: 250 credits per day, 20 ship shares.`
-			`	Pilots are who you rely upon most to manage other ships in your fleet. Be they high-risk fighter jockeys, or the people running your heavy escorts. Their job is to fly any ships that you don't, and they get paid extra for it.`
-			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not actually take on the responsibility of being a Captain, and will seldom act independently of you. They will do their best to your orders to the letter when possible.`
+			`	Pilots: 500 credits per day, 10 fleet shares.`
+			`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it.`
+			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 			``
-			`	Even Pirates, who mostly run on slave labor, abide by the rules requiring officers. Although it is suspected Pirate crews abide by this largely due to improved performance.`
+			`	Even Pirates that utilise slave labor abide by the laws requiring officers. That said, many suspect that Pirate crews do it simply because they can't run their ships effectively without them.`
 			``
-			`	Junior Officers: 500 credits per day, 10 ship shares.`
-			`	These officers manage teams of about five regular crewmen, and you will automatically hire one for ever five crewmen you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less ship shares.`
-			`	Junior Officers are required by both law and moral codes of conduct for every five crewmen aboard any ship.`
+			`	Junior Officers: 1000 credits per day, 5 fleet shares.`
+			`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less fleet shares.`
+			`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 			``
-			`	Senior Officers: 1,000 credits per day, 50 ship shares.`
-			`	The largest ships and fleets will need Senior Officers. Experienced managers who can efficiently run large groups of crewmen and direct them.`
-			`	Senior Officers are required by both law and moral codes of conduct for every twenty crewmen aboard any ship.`
+			`	Senior Officers: 2,000 credits per day, 20 fleet shares.`
+			`	Large ships require Senior Officers to operate the bridge and coordinate the Junior Officers that serve under them. These crew members are experienced decision makers who have command experience and know their ship inside out. Many are former ship captains that have opted for employment as a less risky way to earn a living.`
+			`	You will automatically hire one Senior Officer for every 20 crew members aboard a given ship.`
+			``
+			`	Executive Officers: 10,000 credits per day, 50 fleet shares.`
+			`	Commanding a heavy warship, city ship, or similarly huge vessel is no easy task; it normally requires someone with years of training and experience. These people are hard to come by, and they charge a lot for their services.`
+			`	You will automatically hire one Executive Officer to command each ship that has at least 50 crew members.`
 		log "Factions" "Republic" `Hundreds of years ago, the independent territories in different parts of human space agreed to join together into a single democratic government, with Earth as its capital. The rise of the Republic ushered in a long period of peace and prosperity in human history.`
 			`Representation in the Republic Parliament is based on population. That means that some individual "Paradise Worlds" have more representatives than entire regions of space like the Dirt Belt that are more sparsely settled.`
 		log "Factions" "Syndicate" `The Syndicate is a mega-corporation, the largest employer in human space. People who cannot find steady work elsewhere flock to the Syndicate factory worlds, where they are almost guaranteed to find a job. Although the Syndicate is technically part of the Republic, Syndicate worlds are governed directly by the corporation.`

--- a/data/resources/crew.txt
+++ b/data/resources/crew.txt
@@ -10,7 +10,7 @@
 
 crew "player"
 	name "Player"
-	shares 1000
+	shares 100
 	"avoids escorts"
 	"place at" 1
 
@@ -21,19 +21,25 @@ crew "regular"
 
 crew "pilot"
 	name "Pilot"
-	salary 250
-	shares 20
+	salary 500
+	shares 10
 	"avoids flagship"
 	"place at" 1
 
 crew "junior officer"
 	name "Junior Officers"
-	salary 500
-	shares 10
+	salary 1000
+	shares 5
 	"ship population per member" 5
 
 crew "senior officer"
 	name "Senior Officers"
 	salary 2000
-	shares 50
+	shares 20
 	"ship population per member" 20
+
+crew "executive officer"
+	name "Executive Officer"
+	salary 5000
+	shares 50
+	"place at" 50


### PR DESCRIPTION
### Context

We've recently added profit sharing to capturing and plundering, but in
the process of our testing we've realised that the profit share ratio
itself isn't high enough to make a big difference.

Profit shares are meant to be really high once the player gets a sizable
fleet to disincentivise them from making it so big that the game loses
all sense of danger or economic challenge.

### Changes

This commit overhauls the data values in `crew.txt` so that the fleet
takes a much greater share of profits than they used to.

It also adds a new type of crew member, the Executive Officer. Each ship
with at least 50 crew members has exactly one of them.

Finally, the commit updates the in-game documentation to better fit the
updated system. Along the way, I removed all instances that implied that
all of the crew were male through terms like 'crewman'.

### Considerations

I tried to design the new version of the documentation in a way that
will make it a bit easier to update when we inevitably want to tweak the
crew data in the future.
