### PR TITLE
Reduce crew salaries because profit is shared

### DIFF
--- a/data/missions/intro conversations.txt
+++ b/data/missions/intro conversations.txt
@@ -135,11 +135,11 @@ conversation "intro"
 	choice	
 		`	You: No salary, 100 fleet shares.`
 			goto crewyou
-		`	Regular Crew: 50 credits per day, 1 fleet share.`
+		`	Regular Crew: 80 credits per day, 1 fleet share.`
 			goto crewreg
-		`	Pilots: 100 credits per day, 20 fleet shares.`
+		`	Pilots: 150 credits per day, 20 fleet shares.`
 			goto crewpilot
-		`	Junior Officers: 150 credits per day, 10 fleet shares.`
+		`	Junior Officers: 200 credits per day, 10 fleet shares.`
 			goto crewjo
 		`	Senior Officers: 300 credits per day, 20 fleet shares.`
 			goto crewso
@@ -169,7 +169,7 @@ conversation "intro"
 			goto logbook
 	label crewreg
 	`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
-	`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least, each drawing a salary of 50 credits per day and only taking one share in the fleet's profits.`
+	`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least, each drawing a salary of 80 credits per day and only taking one share in the fleet's profits.`
 	`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 	choice	
 		`	(Back to the Crew overview.)`
@@ -181,7 +181,7 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewpilot
-	`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it: 100 credits per day, and 10 fleet shares.`
+	`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it: 150 credits per day, and 10 fleet shares.`
 	`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have on any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 	choice	
 		`	(Back to the Crew overview.)`
@@ -193,7 +193,7 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewjo
-	`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but a little safer than those of your pilots, so they draw a heavier salary of 150 credits per day, but take only 5 shares of any profit.`
+	`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but a little safer than those of your pilots, so they draw a heavier salary of 200 credits per day, but take only 5 shares of any profit.`
 	`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 	choice	
 		`	(Back to the Crew overview.)`

--- a/data/missions/intro conversations.txt
+++ b/data/missions/intro conversations.txt
@@ -135,15 +135,15 @@ conversation "intro"
 	choice	
 		`	You: No salary, 100 fleet shares.`
 			goto crewyou
-		`	Regular Crew: 100 credits per day, 1 fleet share.`
+		`	Regular Crew: 50 credits per day, 1 fleet share.`
 			goto crewreg
-		`	Pilots: 1,000 credits per day, 20 fleet shares.`
+		`	Pilots: 100 credits per day, 20 fleet shares.`
 			goto crewpilot
-		`	Junior Officers: 500 credits per day, 10 fleet shares.`
+		`	Junior Officers: 150 credits per day, 10 fleet shares.`
 			goto crewjo
-		`	Senior Officers: 2,000 credits per day, 20 fleet shares.`
+		`	Senior Officers: 300 credits per day, 20 fleet shares.`
 			goto crewso
-		`	Executive Officers: 10,000 credits per day, 50 fleet shares.`
+		`	Executive Officers: 1,000 credits per day, 50 fleet shares.`
 			goto crewxo
 		`	Credits per day?`
 			goto crewcredits
@@ -169,7 +169,7 @@ conversation "intro"
 			goto logbook
 	label crewreg
 	`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
-	`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least, each drawing a salary of 100 credits per day and only taking one share in the fleet's profits.`
+	`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least, each drawing a salary of 50 credits per day and only taking one share in the fleet's profits.`
 	`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 	choice	
 		`	(Back to the Crew overview.)`
@@ -181,7 +181,7 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewpilot
-	`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it: 500 credits per day, and 10 fleet shares.`
+	`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it: 100 credits per day, and 10 fleet shares.`
 	`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have on any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 	choice	
 		`	(Back to the Crew overview.)`
@@ -193,7 +193,7 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewjo
-	`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but a little safer than those of your pilots, so they draw a heavier salary of 1,000 credits per day, but take only 5 shares of any profit.`
+	`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but a little safer than those of your pilots, so they draw a heavier salary of 150 credits per day, but take only 5 shares of any profit.`
 	`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 	choice	
 		`	(Back to the Crew overview.)`
@@ -205,7 +205,7 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewso
-	`	Large ships require Senior Officers to operate the bridge and coordinate the Junior Officers that serve under them. These crew members are experienced decision makers who have command experience, and they usually know their ship inside out. Many are former ship captains that have opted for employment as a less risky way to earn a living. You pay them well: 2,000 credits per day and 20 shares in the fleet's profits.`
+	`	Large ships require Senior Officers to operate the bridge and coordinate the Junior Officers that serve under them. These crew members are experienced decision makers who have command experience, and they usually know their ship inside out. Many are former ship captains that have opted for employment as a less risky way to earn a living. You pay them well: 300 credits per day and 20 shares in the fleet's profits.`
 	`	You will automatically hire one Senior Officer for every 20 crew members aboard a given ship.`
 	choice	
 		`	(Back to the Crew overview.)`
@@ -217,7 +217,7 @@ conversation "intro"
 		`	(Continue to the intro.)`
 			goto logbook
 	label crewxo
-	`	Commanding a heavy warship, city ship, or similarly huge vessel is no easy task; it normally requires someone with years of training and experience. These people are hard to come by, and they charge a lot for their services. You pay each of them 5,000 credits per day and 50 shares in the fleet's profits.`
+	`	Commanding a heavy warship, city ship, or similarly huge vessel is no easy task; it normally requires someone with years of training and experience. These people are hard to come by, and they charge a lot for their services. You pay each of them 1,000 credits per day and 50 shares in the fleet's profits.`
 	`	You will automatically hire one Executive Officer to command each ship that has at least 50 crew members.`
 	choice	
 		`	(Back to the Crew overview.)`

--- a/data/missions/intro missions.txt
+++ b/data/missions/intro missions.txt
@@ -75,18 +75,18 @@ mission "Trust fund baby"
 			`	You are part of the crew of your own ship, with all the rights and privileges that brings. However, you are also in charge, so you get treated quite differently.`
 			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 			``
-			`	Regular Crew: 50 credits per day, 1 fleet share.`
+			`	Regular Crew: 80 credits per day, 1 fleet share.`
 			`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
 			`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least.`
 			`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 			``
-			`	Pilots: 100 credits per day, 10 fleet shares.`
+			`	Pilots: 150 credits per day, 10 fleet shares.`
 			`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it.`
 			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 			``
 			`	Even Pirates that utilise slave labor abide by the laws requiring officers. That said, many suspect that Pirate crews do it simply because they can't run their ships effectively without them.`
 			``
-			`	Junior Officers: 150 credits per day, 5 fleet shares.`
+			`	Junior Officers: 200 credits per day, 5 fleet shares.`
 			`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less fleet shares.`
 			`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 			``
@@ -184,18 +184,18 @@ mission "Perfectly Vanilla"
 			`	You are part of the crew of your own ship, with all the rights and privileges that brings. However, you are also in charge, so you get treated quite differently.`
 			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 			``
-			`	Regular Crew: 50 credits per day, 1 fleet share.`
+			`	Regular Crew: 80 credits per day, 1 fleet share.`
 			`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
 			`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least.`
 			`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 			``
-			`	Pilots: 100 credits per day, 10 fleet shares.`
+			`	Pilots: 150 credits per day, 10 fleet shares.`
 			`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it.`
 			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 			``
 			`	Even Pirates that utilise slave labor abide by the laws requiring officers. That said, many suspect that Pirate crews do it simply because they can't run their ships effectively without them.`
 			``
-			`	Junior Officers: 150 credits per day, 5 fleet shares.`
+			`	Junior Officers: 200 credits per day, 5 fleet shares.`
 			`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less fleet shares.`
 			`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 			``
@@ -289,18 +289,18 @@ mission "A pirate's life!"
 			`	You are part of the crew of your own ship, with all the rights and privileges that brings. However, you are also in charge, so you get treated quite differently.`
 			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 			``
-			`	Regular Crew: 50 credits per day, 1 fleet share.`
+			`	Regular Crew: 80 credits per day, 1 fleet share.`
 			`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
 			`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least.`
 			`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 			``
-			`	Pilots: 100 credits per day, 10 fleet shares.`
+			`	Pilots: 150 credits per day, 10 fleet shares.`
 			`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it.`
 			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 			``
 			`	Even Pirates that utilise slave labor abide by the laws requiring officers. That said, many suspect that Pirate crews do it simply because they can't run their ships effectively without them.`
 			``
-			`	Junior Officers: 150 credits per day, 5 fleet shares.`
+			`	Junior Officers: 200 credits per day, 5 fleet shares.`
 			`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less fleet shares.`
 			`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 			``

--- a/data/missions/intro missions.txt
+++ b/data/missions/intro missions.txt
@@ -75,26 +75,26 @@ mission "Trust fund baby"
 			`	You are part of the crew of your own ship, with all the rights and privileges that brings. However, you are also in charge, so you get treated quite differently.`
 			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 			``
-			`	Regular Crew: 100 credits per day, 1 fleet share.`
+			`	Regular Crew: 50 credits per day, 1 fleet share.`
 			`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
 			`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least.`
 			`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 			``
-			`	Pilots: 500 credits per day, 10 fleet shares.`
+			`	Pilots: 100 credits per day, 10 fleet shares.`
 			`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it.`
 			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 			``
 			`	Even Pirates that utilise slave labor abide by the laws requiring officers. That said, many suspect that Pirate crews do it simply because they can't run their ships effectively without them.`
 			``
-			`	Junior Officers: 1000 credits per day, 5 fleet shares.`
+			`	Junior Officers: 150 credits per day, 5 fleet shares.`
 			`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less fleet shares.`
 			`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 			``
-			`	Senior Officers: 2,000 credits per day, 20 fleet shares.`
+			`	Senior Officers: 300 credits per day, 20 fleet shares.`
 			`	Large ships require Senior Officers to operate the bridge and coordinate the Junior Officers that serve under them. These crew members are experienced decision makers who have command experience and know their ship inside out. Many are former ship captains that have opted for employment as a less risky way to earn a living.`
 			`	You will automatically hire one Senior Officer for every 20 crew members aboard a given ship.`
 			``
-			`	Executive Officers: 10,000 credits per day, 50 fleet shares.`
+			`	Executive Officers: 1,000 credits per day, 50 fleet shares.`
 			`	Commanding a heavy warship, city ship, or similarly huge vessel is no easy task; it normally requires someone with years of training and experience. These people are hard to come by, and they charge a lot for their services.`
 			`	You will automatically hire one Executive Officer to command each ship that has at least 50 crew members.`
 		log "Factions" "Republic" `Hundreds of years ago, the independent territories in different parts of human space agreed to join together into a single democratic government, with Earth as its capital. The rise of the Republic ushered in a long period of peace and prosperity in human history.`
@@ -184,26 +184,26 @@ mission "Perfectly Vanilla"
 			`	You are part of the crew of your own ship, with all the rights and privileges that brings. However, you are also in charge, so you get treated quite differently.`
 			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 			``
-			`	Regular Crew: 100 credits per day, 1 fleet share.`
+			`	Regular Crew: 50 credits per day, 1 fleet share.`
 			`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
 			`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least.`
 			`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 			``
-			`	Pilots: 500 credits per day, 10 fleet shares.`
+			`	Pilots: 100 credits per day, 10 fleet shares.`
 			`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it.`
 			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 			``
 			`	Even Pirates that utilise slave labor abide by the laws requiring officers. That said, many suspect that Pirate crews do it simply because they can't run their ships effectively without them.`
 			``
-			`	Junior Officers: 1000 credits per day, 5 fleet shares.`
+			`	Junior Officers: 150 credits per day, 5 fleet shares.`
 			`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less fleet shares.`
 			`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 			``
-			`	Senior Officers: 2,000 credits per day, 20 fleet shares.`
+			`	Senior Officers: 300 credits per day, 20 fleet shares.`
 			`	Large ships require Senior Officers to operate the bridge and coordinate the Junior Officers that serve under them. These crew members are experienced decision makers who have command experience and know their ship inside out. Many are former ship captains that have opted for employment as a less risky way to earn a living.`
 			`	You will automatically hire one Senior Officer for every 20 crew members aboard a given ship.`
 			``
-			`	Executive Officers: 10,000 credits per day, 50 fleet shares.`
+			`	Executive Officers: 1,000 credits per day, 50 fleet shares.`
 			`	Commanding a heavy warship, city ship, or similarly huge vessel is no easy task; it normally requires someone with years of training and experience. These people are hard to come by, and they charge a lot for their services.`
 			`	You will automatically hire one Executive Officer to command each ship that has at least 50 crew members.`
 		log "Factions" "Republic" `Hundreds of years ago, the independent territories in different parts of human space agreed to join together into a single democratic government, with Earth as its capital. The rise of the Republic ushered in a long period of peace and prosperity in human history.`
@@ -289,26 +289,26 @@ mission "A pirate's life!"
 			`	You are part of the crew of your own ship, with all the rights and privileges that brings. However, you are also in charge, so you get treated quite differently.`
 			`	You will draw no salary out of your own bank account because, well, it's your bank account. You also get 100 fleet shares, so you should always get a greater share of the profits than any other individual crew member.`
 			``
-			`	Regular Crew: 100 credits per day, 1 fleet share.`
+			`	Regular Crew: 50 credits per day, 1 fleet share.`
 			`	Ships need an assortment of different crew members to handle various duties. These include maintaining the ship, cooking, cleaning, hosting passengers, firing the ship's weapons, operating the engineering bay, providing security, and more.`
 			`	Your most common crew members, the "Regular Crew", handle these jobs. They also cost the least.`
 			`	Some, usually cruel, captains have been known to throw hoards of their Regular Crew at hostile ships in boarding operations. Most people find this distasteful, and it is absolutely an abuse of your workforce. However, thanks to the Syndicate's economic influence, the Republic has yet to pass any laws restricting or prohibiting the practice.`
 			``
-			`	Pilots: 500 credits per day, 10 fleet shares.`
+			`	Pilots: 100 credits per day, 10 fleet shares.`
 			`	You rely on pilots to fly the other ships in your fleet. These crew members range from your high-risk fighter jockies to the seasoned helm officers that steer your heavy freighters and warships. Their job is important, so they get paid well for it.`
 			`	Although Pilots take your place aboard any ship you aren't currently flying, they do not have any officer responsibilities. They will seldom act independently of you, preferring to follow your orders to the letter.`
 			``
 			`	Even Pirates that utilise slave labor abide by the laws requiring officers. That said, many suspect that Pirate crews do it simply because they can't run their ships effectively without them.`
 			``
-			`	Junior Officers: 1000 credits per day, 5 fleet shares.`
+			`	Junior Officers: 150 credits per day, 5 fleet shares.`
 			`	These officers manage teams of about five regular crew members, and you will automatically hire one for ever five crew members you have. Their jobs are more challenging but less high risk than that of your pilots, so they draw a heavier salary, but take less fleet shares.`
 			`	You will automatically hire one Junior Officer for every 5 crew members aboard a given ship.`
 			``
-			`	Senior Officers: 2,000 credits per day, 20 fleet shares.`
+			`	Senior Officers: 300 credits per day, 20 fleet shares.`
 			`	Large ships require Senior Officers to operate the bridge and coordinate the Junior Officers that serve under them. These crew members are experienced decision makers who have command experience and know their ship inside out. Many are former ship captains that have opted for employment as a less risky way to earn a living.`
 			`	You will automatically hire one Senior Officer for every 20 crew members aboard a given ship.`
 			``
-			`	Executive Officers: 10,000 credits per day, 50 fleet shares.`
+			`	Executive Officers: 1,000 credits per day, 50 fleet shares.`
 			`	Commanding a heavy warship, city ship, or similarly huge vessel is no easy task; it normally requires someone with years of training and experience. These people are hard to come by, and they charge a lot for their services.`
 			`	You will automatically hire one Executive Officer to command each ship that has at least 50 crew members.`
 		log "Factions" "Republic" `Hundreds of years ago, the independent territories in different parts of human space agreed to join together into a single democratic government, with Earth as its capital. The rise of the Republic ushered in a long period of peace and prosperity in human history.`

--- a/data/resources/crew.txt
+++ b/data/resources/crew.txt
@@ -16,30 +16,30 @@ crew "player"
 
 crew "regular"
 	name "Regular Crew"
-	salary 100
+	salary 50
 	shares 1
 
 crew "pilot"
 	name "Pilot"
-	salary 500
+	salary 100
 	shares 10
 	"avoids flagship"
 	"place at" 1
 
 crew "junior officer"
 	name "Junior Officers"
-	salary 1000
+	salary 150
 	shares 5
 	"ship population per member" 5
 
 crew "senior officer"
 	name "Senior Officers"
-	salary 2000
+	salary 300
 	shares 20
 	"ship population per member" 20
 
 crew "executive officer"
 	name "Executive Officer"
-	salary 5000
+	salary 1000
 	shares 50
 	"place at" 50

--- a/data/resources/crew.txt
+++ b/data/resources/crew.txt
@@ -16,19 +16,19 @@ crew "player"
 
 crew "regular"
 	name "Regular Crew"
-	salary 50
+	salary 80
 	shares 1
 
 crew "pilot"
 	name "Pilot"
-	salary 100
+	salary 150
 	shares 10
 	"avoids flagship"
 	"place at" 1
 
 crew "junior officer"
 	name "Junior Officers"
-	salary 150
+	salary 200
 	shares 5
 	"ship population per member" 5
 


### PR DESCRIPTION
### Context

We recently overhauled the crew salaries and fleet shares to make the
game more economically challenging. In doing so, we revealed that
missions don't pay well enough, and that daily salaries are not as fun
as profit shares are. This commit addresses the latter issue.

Overall, we want the player to feel like their fleet costs them
something each day. However, we don't want to to tie the player's hands
and punish them for spending several days doing something fun like
exploring the galaxy.

### Changes

This commit significantly reduces the salaries of all crew members:

> Regular Crew: 100 -> 80
> Pilot: 500 -> 150
> Junior Officer: 1000 -> 200
> Senior Officer: 2000 -> 300
> Executive Officer: 10,000 -> 1,000

### Considerations

Under this model, a person would choose to become a crew member on a
starship not because of the daily pay, which might be better working on
a planet, but for the potential profit shares. They become the focus.

I think that this model lays a better foundation for the upcoming morale
system. If crew members don't get a huge daily salary, then shared
profits are therefore their main motivator. That opens the door for
their morale to be more variable.

When they're making a lot of money because the fleet is smart and
productive, they'll be a lot happier.
  
When the crew aren't seeing enough profits to justify their risks,
they'll become unhappy, be less motivated to run the ship well, and
eventually get mad enough to mutiny.
